### PR TITLE
Improved consistency across examples.

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -84,7 +84,7 @@ export default function Layout({ meta, children }) {
                       language: 'html',
                       code: dedent`
                         <template>
-                          <layout title="Users">
+                          <layout>
                             <div v-for="user in users" :key="user.id">
                               <inertia-link :href="\`/users/\${user.id}\`">
                                 {{ user.name }}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -84,7 +84,7 @@ export default function Layout({ meta, children }) {
                       language: 'html',
                       code: dedent`
                         <template>
-                          <layout>
+                          <layout title="Users">
                             <div v-for="user in users" :key="user.id">
                               <inertia-link :href="\`/users/\${user.id}\`">
                                 {{ user.name }}

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -5,11 +5,15 @@ export const meta = { title: 'Introduction', hero: true }
 
 # Introduction
 
-Inertia is a new approach to building classic server-driven web apps. We call it the modern monolith. Inspired by Turbolinks, Inertia allows you to create fully client-side rendered, single-page apps, without much of the complexity that comes with modern SPAs. It does this by leveraging existing server-side frameworks. Inertia has no client-side routing, nor does it require an API. Simply build controllers and page views like you've always done! To learn more about how Inertia works, see our how it works page.
+Inertia is a new approach to building classic server-driven web apps. We call it the modern monolith.
 
-~~~html
+Inertia allows you to create fully client-side rendered, single-page apps, without much of the complexity that comes with modern SPAs. It does this by leveraging existing server-side frameworks.
+
+Inertia has no client-side routing, nor does it require an API. Simply build controllers and page views like you've always done! To learn more about how Inertia works, see our how it works page.
+
+```html
 <inertia-link :href="`/users/\${user.id}`">Edit</inertia-link>
-~~~
+```
 
 ## Adapters
 

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -8,7 +8,7 @@ export const meta = { title: 'Introduction', hero: true }
 Inertia is a new approach to building classic server-driven web apps. We call it the modern monolith. Inspired by Turbolinks, Inertia allows you to create fully client-side rendered, single-page apps, without much of the complexity that comes with modern SPAs. It does this by leveraging existing server-side frameworks. Inertia has no client-side routing, nor does it require an API. Simply build controllers and page views like you've always done! To learn more about how Inertia works, see our how it works page.
 
 ~~~html
-<inertia-link :href="route('users.edit', user.id)">Edit</inertia-link>
+<inertia-link :href="`/users/\${user.id}`">Edit</inertia-link>
 ~~~
 
 ## Adapters


### PR DESCRIPTION
I'm worried about the consistency for the examples provided.

Even though I'm guessing the majority of developers using InertiaJS today are making use of the `Layout.vue` file that comes with PingCRM, as well as using TightenCo's Ziggy package, I still don't think they should be used in examples designed to showcase InertiaJS.