### PR TITLE
Fix import for use `visit` on React

### DIFF
--- a/pages/requests.mdx
+++ b/pages/requests.mdx
@@ -78,7 +78,7 @@ In addition to [creating links](/links), it's also very common to manually make 
       name: 'React',
       language: 'js',
       code: dedent`
-        import { Inertia } from 'inertia-react'\n
+        import { Inertia } from '@inertiajs/inertia'\n
         Inertia.visit(url, {
           method: 'get',
           data: {},


### PR DESCRIPTION
Hi,

I think that the import in React docs is wrong, and possibly the others in the same page.

Thanks for the library, looks good!