### PR TITLE
Fix imports on react examples (missing namespace, hook names)

### DIFF
--- a/pages/local-state-caching.mdx
+++ b/pages/local-state-caching.mdx
@@ -55,7 +55,7 @@ To mitigate this issue, you can tell Inertia which local component state to cach
       description: 'Use the "useRememberedState" hook to cache local state.',
       language: 'jsx',
       code: dedent`
-        import { useRememberedState } from 'inertia-react'
+        import { useRememberedState } from '@inertiajs/inertia-react'
         import React from 'react'\n
         export default function Profile() {
           const [formState, setFormState] = useRememberedState({
@@ -128,7 +128,7 @@ If you have multiple instances of the same component on the page, be sure to inc
       language: 'jsx',
       code:
         dedent`
-        import { useRememberedState } from 'inertia-react'
+        import { useRememberedState } from '@inertiajs/inertia-react'
         import React from 'react'\n
         export default function Profile() {
           const [formState, setFormState] = useRememberedState(

--- a/pages/pages.mdx
+++ b/pages/pages.mdx
@@ -124,7 +124,7 @@ While not required, for most projects it makes sense to create a site layout tha
       language: 'jsx',
       code: dedent`
         import React, { useEffect } from 'react'
-        import { InertiaLink } from 'inertia-react'\n
+        import { InertiaLink } from '@inertiajs/inertia-react'\n
         export default function Layout({ title, children }) {
           useEffect(() => document.title = title, [title])\n
           return (

--- a/pages/shared-data.mdx
+++ b/pages/shared-data.mdx
@@ -116,12 +116,12 @@ Once you've shared the data server-side, you'll then be able to access it within
     },
     {
       name: 'React',
-      description: 'Access shared data using the usePageProps() hook.',
+      description: 'Access shared data using the usePage() hook.',
       language: 'jsx',
       code: dedent`
-        import { InertiaLink, usePageProps } from '@inertiajs/inertia-react'\n
+        import { InertiaLink, usePage } from '@inertiajs/inertia-react'\n
         export default function Layout({ children }) {
-          const { auth } = usePageProps()\n
+          const { auth } = usePage()\n
           return (
             <main>
               <header>
@@ -224,9 +224,9 @@ Next, display the flash message in a front-end component, such as the site layou
       name: 'React',
       language: 'jsx',
       code: dedent`
-        import { usePageProps } from '@inertiajs/inertia-react'\n
+        import { usePage } from '@inertiajs/inertia-react'\n
         export default function Layout({ children }) {
-          const { flash } = usePageProps()\n
+          const { flash } = usePage()\n
           return (
             <main>
               <header></header>

--- a/pages/shared-data.mdx
+++ b/pages/shared-data.mdx
@@ -119,7 +119,7 @@ Once you've shared the data server-side, you'll then be able to access it within
       description: 'Access shared data using the usePageProps() hook.',
       language: 'jsx',
       code: dedent`
-        import { InertiaLink, usePageProps } from 'inertia-react'\n
+        import { InertiaLink, usePageProps } from '@inertiajs/inertia-react'\n
         export default function Layout({ children }) {
           const { auth } = usePageProps()\n
           return (
@@ -224,7 +224,7 @@ Next, display the flash message in a front-end component, such as the site layou
       name: 'React',
       language: 'jsx',
       code: dedent`
-        import { usePageProps } from 'inertia-react'\n
+        import { usePageProps } from '@inertiajs/inertia-react'\n
         export default function Layout({ children }) {
           const { flash } = usePageProps()\n
           return (

--- a/pages/transforming-props.mdx
+++ b/pages/transforming-props.mdx
@@ -36,7 +36,7 @@ Sometimes it can be useful to transform the props client-side before they are pa
       name: 'React',
       language: 'jsx',
       code: dedent`
-        import Inertia from 'inertia-react'
+        import { Inertia } from '@inertiajs/inertia'
         import React from 'react'
         import { render } from 'react-dom'\n
         const app = document.getElementById('app')\n


### PR DESCRIPTION
Hi! Another round fixing some react imports. :smile: 