### PR TITLE
Add documentation for scoped slot rendering in vue

### DIFF
--- a/pages/links.mdx
+++ b/pages/links.mdx
@@ -13,6 +13,7 @@ export const meta = {
     { url: '#replace', name: 'Replace' },
     { url: '#preserve-state', name: 'Preserve state' },
     { url: '#preserve-scroll', name: 'Preserve scroll' },
+    { url: '#changing-the-tag', name: 'Changing the tag'},
   ],
 }
 
@@ -198,6 +199,26 @@ By default page visits will automatically reset the scroll position back to the 
       language: 'html',
       code: dedent`
         <InertiaLink href="/" preserveScroll>Home</InertiaLink>
+      `,
+    },
+  ]}
+/>
+
+## Changing the tag
+
+By default the InertiaLink component will render a `<a>` tag. You can overwrite the default tag and use your own components instead. This will be useful when using a component framework for example.
+
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Vue',
+      language: 'twig',
+      code: dedent`
+        <inertia-link href="/" v-slot="{ href, navigate }">
+            <button :href="href" @click="navigate">
+                Home
+            </button>
+        </inertia-link>
       `,
     },
   ]}


### PR DESCRIPTION
Add documentation for https://github.com/inertiajs/inertia-vue/pull/96. I'm not quite sure if this is the right place to document it or if it's the right place to add vue-only docs at all. Maybe this should be listed under advanced instead?