### PR TITLE
Update rails docs

### DIFF
--- a/pages/asset-versioning.mdx
+++ b/pages/asset-versioning.mdx
@@ -38,12 +38,12 @@ To enable automatic asset refreshing, you simply need to tell Inertia what the c
       name: 'Rails',
       language: 'ruby',
       code: dedent`
-        Inertia.configure do |config|
+        InertiaRails.configure do |config|
           config.version = '1.0'
         end\n
         # You can also use lazy evaluation
-        Inertia.configure do |config|
-          config.version = lambda { Version.last }
+        InertiaRails.configure do |config|
+          config.version = lambda { InertiaRails::Version.last }
         end
       `,
     },

--- a/pages/forms.mdx
+++ b/pages/forms.mdx
@@ -111,7 +111,7 @@ Unlike a classic ajax submitted form, with Inertia you don't handle the post sub
           def index
             render inertia: 'Users/Index', props: {users: User.all}
           end\n
-          def store
+          def create
             User.create params.require(:user).permit(:first_name, :last_name, :email)\n
             redirect_to users_path
           end

--- a/pages/redirects.mdx
+++ b/pages/redirects.mdx
@@ -51,7 +51,7 @@ Inertia will automatically follow this redirect and update the page accordingly.
           def index
             render inertia: 'Users/Index', props: {users: User.all}
           end\n
-          def store
+          def create
             User.create params.require(:user).permit(:name, :email)\n
             redirect_to users_path
           end

--- a/pages/server-side-setup.mdx
+++ b/pages/server-side-setup.mdx
@@ -34,7 +34,7 @@ Install the Inertia server-side adapters using the preferred package manager for
       language: 'bash',
       description: 'Install via RubyGems',
       code: dedent`
-        gem install inertia-rails
+        gem install inertia_rails
       `,
     },
   ]}
@@ -69,7 +69,7 @@ Next, setup the root template that will be loaded on the first page visit. This 
       name: 'Rails',
       language: 'ruby',
       code: dedent`
-        Inertia.configure do |config|
+        InertiaRails.configure do |config|
           config.layout = 'inertia' # uses layouts/inertia.html.erb
         end
       `,
@@ -95,7 +95,7 @@ While not required, it's highly recommended that you also configure automatic as
       name: 'Rails',
       language: 'ruby',
       code: dedent`
-        Inertia.configure do |config|
+        InertiaRails.configure do |config|
           config.version = '1.0'
         end
       `,


### PR DESCRIPTION
We published the rails adapter gem on Rubygems today:

https://rubygems.org/gems/inertia_rails

So this just updates the documentation to match that... namely

* Correcting the name of the gem
* Changing the `Inertia` constant to `InertiaRails` because `Intertia` is an existing gem

It also changes the controller method names to match rails conventions.

There are a bunch of other places where the docs need to be updated with Rails specific stuff, but that will take a heavier lift and I want to be sure that the basic gem information is correct here!