### PR TITLE
Update import statements for Svelte

### DIFF
--- a/pages/local-state-caching.mdx
+++ b/pages/local-state-caching.mdx
@@ -73,7 +73,7 @@ To mitigate this issue, you can tell Inertia which local component state to cach
       language: 'html',
       code: dedent`
         <script>
-          import { Inertia, remember } from 'inertia-svelte'\n
+          import { Inertia, remember } from '@inertiajs/inertia-svelte'\n
           let form = remember({
             first_name: null,
             last_name: null,
@@ -151,7 +151,7 @@ If you have multiple instances of the same component on the page, be sure to inc
       code:
         dedent`
         <script>
-          import { Inertia, page, remember } from 'inertia-svelte'\n
+          import { Inertia, page, remember } from '@inertiajs/inertia-svelte'\n
           $: ({ user } = $page)\n
           let form = remember({
             first_name: null,

--- a/pages/pages.mdx
+++ b/pages/pages.mdx
@@ -145,7 +145,7 @@ While not required, for most projects it makes sense to create a site layout tha
       language: 'html',
       code: dedent`
         <script>
-          import { InertiaLink } from 'inertia-svelte'\n
+          import { InertiaLink } from '@inertiajs/inertia-svelte'\n
           export let title
         </script>\n
         <svelte:head>

--- a/pages/shared-data.mdx
+++ b/pages/shared-data.mdx
@@ -145,7 +145,7 @@ Once you've shared the data server-side, you'll then be able to access it within
       language: 'html',
       code: dedent`
         <script>
-          import { InertiaLink, page } from 'inertia-svelte'
+          import { InertiaLink, page } from '@inertiajs/inertia-svelte'
         </script>\n
         <main>
           <header>
@@ -247,7 +247,7 @@ Next, display the flash message in a front-end component, such as the site layou
       language: 'html',
       code: dedent`
         <script>
-          import { page } from 'inertia-svelte'
+          import { page } from '@inertiajs/inertia-svelte'
         </script>\n
         <main>
           <header></header>


### PR DESCRIPTION
Hi, 

First of all, thanks for this amazing package and it's adapters. I've noticed this little typo, while reading through docs. Package names for [Svelte](https://svelte.dev/) are incorrect. 

This PR updates import paths from `inertia-svelte` to `@inertiajs/inertia-svelte` on the following pages: 

- [Pages](https://inertiajs.com/pages)
- [Shared data](https://inertiajs.com/shared-data)
- [Local state caching](https://inertiajs.com/local-state-caching) 

```js
import { ... } from 'inertia-svelte' // incorrect
import { ... } from '@inertiajs/inertia-svelte' // correct
```
