### PR TITLE
Update .gitignore to remove .idea folder and Update error-handling page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /out
 /node_modules
 .DS_Store
+.idea
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -3086,7 +3086,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3104,11 +3105,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3121,15 +3124,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3232,7 +3238,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3242,6 +3249,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3254,17 +3262,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3281,6 +3292,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3353,7 +3365,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3363,6 +3376,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3438,7 +3452,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3468,6 +3483,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3485,6 +3501,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3523,11 +3540,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/pages/error-handling.mdx
+++ b/pages/error-handling.mdx
@@ -39,11 +39,17 @@ In production you'll want to return a proper Inertia error response instead of r
       name: 'Laravel',
       language: 'php',
       code: dedent`
+         /**
+          * Default Laravel location: App\\Exceptions\\Handler.php
+          */ /n
         use Inertia\\Inertia;\n
         public function render($request, Exception $exception)
         {
             $response = parent::render($request, $exception);\n
-            if ($request->header('X-Inertia') && in_array($response->status(), [500, 503, 404, 403])) {
+            if (
+                App::environment('production')
+                && $request->header('X-Inertia')
+                && in_array($response->status(), [500, 503, 404, 403])) {
                 return Inertia::render('Error', ['status' => $response->status()])
                     ->toResponse($request)
                     ->setStatusCode($response->status());


### PR DESCRIPTION
Prior to this commit (7d5ccab) if a user pulls the site into an Intellij IDE, the .idea folder would be uploaded as part of the push.  

After this commit the .gitignore  file includes the .idea folder, which prevents it from being uploaded.  

Prior to this commit (7b8b448) the error-handling page did not list the actual file location of the helper.php file, nor did it provide an environment check for the Laravel portion of the code.

After this commit, the error handling page lists the default Laravel location of the handler.php page as a comment in the code example.  Also, I have added a third check within the if statement to check if the environment is set to production.  