### PR TITLE
Improve error handling docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /out
 /node_modules
 .DS_Store
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /out
 /node_modules
 .DS_Store
+.idea

--- a/pages/error-handling.mdx
+++ b/pages/error-handling.mdx
@@ -32,6 +32,7 @@ Inertia solves this by showing all non-Inertia responses in a modal. Meaning you
 ## In production
 
 In production you'll want to return a proper Inertia error response instead of relying on the modal behaviour. To do this you'll need to update your framework's default exception handler to return a custom error page.
+
 <TabbedCodeExamples
   examples={[
     {

--- a/pages/error-handling.mdx
+++ b/pages/error-handling.mdx
@@ -39,11 +39,16 @@ In production you'll want to return a proper Inertia error response instead of r
       name: 'Laravel',
       language: 'php',
       code: dedent`
+       /**
+        * Default Laravel location: App\\Exceptions\\Handler.php
+        */ \n
         use Inertia\\Inertia;\n
         public function render($request, Exception $exception)
         {
             $response = parent::render($request, $exception);\n
-            if ($request->header('X-Inertia') && in_array($response->status(), [500, 503, 404, 403])) {
+            if (App::environment('production')
+                && $request->header('X-Inertia')
+                && in_array($response->status(), [500, 503, 404, 403])) {
                 return Inertia::render('Error', ['status' => $response->status()])
                     ->toResponse($request)
                     ->setStatusCode($response->status());

--- a/pages/error-handling.mdx
+++ b/pages/error-handling.mdx
@@ -32,23 +32,22 @@ Inertia solves this by showing all non-Inertia responses in a modal. Meaning you
 ## In production
 
 In production you'll want to return a proper Inertia error response instead of relying on the modal behaviour. To do this you'll need to update your framework's default exception handler to return a custom error page.
-
 <TabbedCodeExamples
   examples={[
     {
       name: 'Laravel',
       language: 'php',
+      description: 'Default Laravel location: App\\Exceptions\\Handler.php',
       code: dedent`
-       /**
-        * Default Laravel location: App\\Exceptions\\Handler.php
-        */ \n
-        use Inertia\\Inertia;\n
+        use Inertia\\Inertia;
+        use Illuminate\\Support\\Facades\\App;\n
         public function render($request, Exception $exception)
         {
             $response = parent::render($request, $exception);\n
             if (App::environment('production')
                 && $request->header('X-Inertia')
-                && in_array($response->status(), [500, 503, 404, 403])) {
+                && in_array($response->status(), [500, 503, 404, 403])
+            ) {
                 return Inertia::render('Error', ['status' => $response->status()])
                     ->toResponse($request)
                     ->setStatusCode($response->status());


### PR DESCRIPTION
Prior to this commit, if a user was editing in an IntelliJ
environment, then a commit would commit the .idea folder
as well.

After this commit, the .idea folder will not longer be
included.

Prior to the second commit,the error-handling.mdx file did not have the default location or the handler.php file, which might confuse new users.  Additionally, there is mention of checking if the site is in production, but the code did not appear to be doing that.

After this commit, the default location is listed as a comment in the code example, and the check is added to the if statement where it verifies it's a inertia request.