### PR TITLE
Form validation with Ruby on Rails

### DIFF
--- a/pages/forms.mdx
+++ b/pages/forms.mdx
@@ -198,7 +198,26 @@ From there you need to send those error messages to your form page component. Yo
       name: 'Rails',
       language: 'ruby',
       code: dedent`
-        # todo
+        class ApplicationController < ActionController::Base
+          inertia_share errors: -> {
+            session.delete(:errors) || []
+          }
+        end
+        
+        class ContactsController < ApplicationController
+          def create
+            contact = Contact.new(contact_params)
+            
+            if contact.save
+              redirect_to contacts_path, notice: 'Contact created.'
+            else
+              # Place the errors in the session, so they are available
+              # after the redirect
+              session[:errors] = contact.errors
+              redirect_to new_contact_path
+            end
+          end
+        end
       `,
     },
   ]}


### PR DESCRIPTION
Code snippet to support service-side form validation in Rails.
Tested in https://github.com/ledermann/pingcrm/

Looking into the PHP example (PingCRM) I don't understand where the errors get into the session. In Rails this needs to be done manually in the controller. Any other ideas?