### PR TITLE
Routing example for Ruby on Rails

### DIFF
--- a/pages/routing.mdx
+++ b/pages/routing.mdx
@@ -18,29 +18,55 @@ With Inertia all routing is defined server-side. Meaning you don't need Vue Rout
 
 Some server-side frameworks allow you to generate URLs from named routes. However, you will not have access to those helpers client-side. Here are a couple ways to still used named routes with Inertia.
 
-The first option is to generate URLs server-side and include them as props. Notice in this example how we're passing the `edit_url` and `create_url` to the `Users` component.
+The first option is to generate URLs server-side and include them as props. Notice in this example how we're passing the `edit_url` and `create_url` to the `Users/Index` component.
 
-```php
-class UsersController
-{
-    public function index()
+<TabbedCodeExamples
+  examples={[
     {
-        $users = User::get()->map(function ($user) {
-            return [
-                'id' => $user->id,
-                'name' => $user->name,
-                'email' => $user->email,
-                'edit_url' => URL::route('users.edit', $user),
-            ];
-        });
-
-        return Inertia::render('Users', [
-            'users' => $users,
-            'create_url' => URL::route('users.create'),
-        ]);
-    }
-}
-```
+      name: 'Laravel',
+      language: 'php',
+      code: dedent`
+        class UsersController extends Controller
+        {
+            public function index()
+            {
+                return Inertia::render('Users/Index', [
+                    'users' => User::all()->map(function ($user) {
+                        return [
+                            'id' => $user->id,
+                            'name' => $user->name,
+                            'email' => $user->email,
+                            'edit_url' => URL::route('users.edit', $user),
+                        ];
+                    }),
+                    'create_url' => URL::route('users.create'),
+                ]);
+            }
+        }
+      `
+    },
+    {
+      name: 'Rails',
+      language: 'ruby',
+      code: dedent`
+        class UsersController < ApplicationController
+          def index
+            render inertia: 'Users/Index', props: {
+              users: User.all.map do |user|
+                user.as_json(
+                  only: [ :id, :name, :email ]
+                ).merge(
+                  edit_url: edit_user_path(user)
+                )
+              end,
+              create_url: new_user_path
+            }
+          end
+        end
+      `
+    },
+  ]}
+/>
 
 Another option is to make your route definitions available client-side as JSON, and then use this to generate URLs from your named routes.
 

--- a/pages/routing.mdx
+++ b/pages/routing.mdx
@@ -85,3 +85,5 @@ Vue.prototype.$route = (...args) => route(...args).url()
 ```html
 <inertia-link :href="$route('users.create')">Create User</inertia-link>
 ```
+
+For Ruby on Rails there is a similar library called <a href="https://github.com/railsware/js-routes">JsRoutes</a>.


### PR DESCRIPTION
Currently, the routing example is PHP only, so I've changed it to a `TabbedCodeExamples` with a Rails example included.

The PHP example was updated and fixed a bit - I'm not a PHP developer so I hope I didn't break anything:

- Changed component name to `Users/Index`, which is a nice convention
- Make use of `User::all()` instead of `User::get()`
- Add missing `... extends Controller`
- Use inline style (like in all other examples) instead of variable `$users`

As a routing library for Rails, I suggest to use [JsRoutes](https://github.com/railsware/js-routes) which works fine - I have used in my [PingCRM demo application for Rails](https://github.com/ledermann/pingcrm).