### PR TITLE
doc: X-CSRF-TOKEN -> X-XSRF-TOKEN per Axios doc

### DIFF
--- a/pages/security.mdx
+++ b/pages/security.mdx
@@ -81,8 +81,8 @@ You can even use the <a href="/shared-data">shared data</a> functionality to aut
 
 However, a better approach is to use the CSRF functionality already built into [axios](https://github.com/axios/axios) for this. Axios is the HTTP library that Inertia uses under the hood.
 
-Axios automatically checks for the existence of an `XSRF-TOKEN` cookie. If it's present, it will then include the token in an `X-CSRF-TOKEN` header for any requests it makes.
+Axios automatically checks for the existence of an `XSRF-TOKEN` cookie. If it's present, it will then include the token in an `X-XSRF-TOKEN` header for any requests it makes.
 
-The easiest way to implement this is using server-side middleware. Simply include the `XSRF-TOKEN` cookie on each response, and then verify the token using the `X-CSRF-TOKEN` header sent in the requests from axios.
+The easiest way to implement this is using server-side middleware. Simply include the `XSRF-TOKEN` cookie on each response, and then verify the token using the `X-XSRF-TOKEN` header sent in the requests from axios.
 
 Some frameworks, such as [Laravel](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php#L176-L188), do this automatically, meaning there is no configuration required.


### PR DESCRIPTION
Accroding to https://github.com/axios/axios#request-config
>  // `xsrfCookieName` is the name of the cookie to use as a value for xsrf token
>  xsrfCookieName: 'XSRF-TOKEN', // default
>
>  // `xsrfHeaderName` is the name of the http header that carries the xsrf token value
>  xsrfHeaderName: 'X-XSRF-TOKEN', // default

I didn't really experiment this, but a quick search in the codebase also indicates that the README doc is right:

https://github.com/axios/axios/search?q=X-CSRF-TOKEN&unscoped_q=X-CSRF-TOKEN  // No result
https://github.com/axios/axios/search?q=X-XSRF-TOKEN&unscoped_q=X-XSRF-TOKEN  // Some result