### PR TITLE
Fix Requests page title incorrectly shown as "Links"

### DIFF
--- a/pages/requests.mdx
+++ b/pages/requests.mdx
@@ -5,7 +5,7 @@ import TabbedCodeExamples from '../components/TabbedCodeExamples'
 
 export default Layout
 export const meta = {
-  title: 'Links',
+  title: 'Requests',
   links: [
     { url: '#top', name: 'Making requests' },
     { url: '#history-state', name: 'History state' },


### PR DESCRIPTION
Fix page title of Requests page incorrectly showing "Links" instead of "Requests".

Quite annoying if you are the type of person who opens a lot of documentation pages at the same time (like me lol).