### PR TITLE
Improve pages docs

### DIFF
--- a/pages/pages.mdx
+++ b/pages/pages.mdx
@@ -207,10 +207,10 @@ For example, maybe you have an audio player on a podcast website that you want t
         import Layout from './Layout'\n
         const Home = ({ user }) => {
           return (
-            <React.Fragment>
+            <>
               <h1>Welcome</h1>
               <p>Hello {user.name}, welcome to your first Inertia app!</p>
-            </React.Fragment>
+            </>
           )
         }\n
         Home.layout = child => <Layout children={child} title="Welcome" />\n
@@ -264,10 +264,10 @@ You can also create more complex layout arrangements using nested layouts.
         import NestedLayout from './NestedLayout'\n
         const Home = ({ user }) => {
           return (
-            <React.Fragment>
+            <>
               <h1>Welcome</h1>
               <p>Hello {user.name}, welcome to your first Inertia app!</p>
-            </React.Fragment>
+            </>
           )
         }\n
         Home.layout = child => (

--- a/pages/pages.mdx
+++ b/pages/pages.mdx
@@ -187,7 +187,10 @@ For example, maybe you have an audio player on a podcast website that you want t
         <script>
           import Layout from '@/Shared/Layout'\n
           export default {
-            layout: Layout,
+            // Using a render function
+            layout: (h, page) => h(Layout, [page]),\n
+            // Using the shorthand
+            layout: Layout,\n
             props: {
               user: Object,
             },

--- a/pages/pages.mdx
+++ b/pages/pages.mdx
@@ -11,6 +11,7 @@ export const meta = {
     { url: '#creating-layouts', name: 'Creating layouts' },
     { url: '#persistent-layouts', name: 'Persistent layouts' },
     { url: '#scroll-regions', name: 'Scroll regions' },
+    { url: '#title-and-meta-tags', name: 'Title and meta tags' },
   ],
 }
 
@@ -294,3 +295,67 @@ When navigating between pages, Inertia will automatically reset the scroll posit
   <!-- Your page content -->
 </div>
 ```
+
+## Title and meta tags
+
+While it's possible to pass title and meta tag props from pages to layouts (as illustrated above), it's often easier to manage this using a document head library like [Vue Meta](https://github.com/nuxt/vue-meta) or [React Helmet](https://github.com/nfl/react-helmet).
+
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Vue',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <layout>
+            <h1>Welcome</h1>
+            <p>Hello {{ user.name }}, welcome to your first Inertia app!</p>
+          </layout>
+        </template>\n
+        <script>
+          import Layout from './Layout'\n
+          export default {
+            metaInfo() {
+              return {
+                title: \`Welcome \${this.user.name}\`,
+              }
+            },
+            components: {
+              Layout,
+            },
+            props: {
+              user: Object,
+            },
+          }
+        </script>
+      `,
+    },
+    {
+      name: 'React',
+      language: 'jsx',
+      code: dedent`
+        import React from 'react'
+        import Layout from './Layout'
+        import {Helmet} from "react-helmet"\n
+        export default function Welcome({ user }) {
+          return (
+            <Layout>
+              <Helmet>
+                <title>Welcome {user.name}</title>
+              </Helmet>
+              <h1>Welcome</h1>
+              <p>Hello {user.name}, welcome to your first Inertia app!</p>
+            </Layout>
+          )
+        }
+      `,
+    },
+    {
+      name: 'Svelte',
+      language: 'js',
+      code: `// Coming soon`,
+    },
+  ]}
+/>
+
+Further, if it's critical for your application to set the page title and meta tags server-side, you can use [root template data](/responses#root-template-data) to accomplish this.

--- a/pages/pages.mdx
+++ b/pages/pages.mdx
@@ -201,7 +201,20 @@ For example, maybe you have an audio player on a podcast website that you want t
     {
       name: 'React',
       language: 'jsx',
-      code: `// Coming soon`,
+      code: dedent`
+        import React from 'react'
+        import Layout from './Layout'\n
+        const Home = ({ user }) => {
+          return (
+            <React.Fragment>
+              <h1>Welcome</h1>
+              <p>Hello {user.name}, welcome to your first Inertia app!</p>
+            </React.Fragment>
+          )
+        }\n
+        Home.layout = child => <Layout children={child} title="Welcome" />\n
+        export default Home
+      `,
     },
     {
       name: 'Svelte',
@@ -211,7 +224,7 @@ For example, maybe you have an audio player on a podcast website that you want t
   ]}
 />
 
-You can optionally make `layout` a render function, allowing you to create more complex layout arrangements. For example, you can use this to create a secondary nested layout within a subsection of your app.
+You can also create more complex layout arrangements using nested layouts.
 
 <TabbedCodeExamples
   examples={[
@@ -244,7 +257,25 @@ You can optionally make `layout` a render function, allowing you to create more 
     {
       name: 'React',
       language: 'jsx',
-      code: `// Coming soon`,
+      code: dedent`
+        import React from 'react'
+        import SiteLayout from './SiteLayout'
+        import NestedLayout from './NestedLayout'\n
+        const Home = ({ user }) => {
+          return (
+            <React.Fragment>
+              <h1>Welcome</h1>
+              <p>Hello {user.name}, welcome to your first Inertia app!</p>
+            </React.Fragment>
+          )
+        }\n
+        Home.layout = child => (
+          <SiteLayout title="Welcome">
+            <NestedLayout children={child} />
+          </SiteLayout>
+        )\n
+        export default Home
+      `,
     },
     {
       name: 'Svelte',

--- a/pages/pages.mdx
+++ b/pages/pages.mdx
@@ -35,7 +35,7 @@ Pages are simply JavaScript components. There is nothing particularly special ab
           </layout>
         </template>\n
         <script>
-          import Layout from '@/Shared/Layout'\n
+          import Layout from './Layout'\n
           export default {
             components: {
               Layout,
@@ -52,7 +52,7 @@ Pages are simply JavaScript components. There is nothing particularly special ab
       language: 'jsx',
       code: dedent`
         import React from 'react'
-        import Layout from '@/Shared/Layout'\n
+        import Layout from './Layout'\n
         export default function Welcome({ user }) {
           return (
             <Layout title="Welcome">
@@ -68,7 +68,7 @@ Pages are simply JavaScript components. There is nothing particularly special ab
       language: 'html',
       code: dedent`
         <script>
-          import Layout from '@/Shared/Layout.svelte'\n
+          import Layout from './Layout.svelte'\n
           export let user
         </script>\n
         <Layout title="Welcome">
@@ -185,7 +185,7 @@ For example, maybe you have an audio player on a podcast website that you want t
           </div>
         </template>\n
         <script>
-          import Layout from '@/Shared/Layout'\n
+          import Layout from './Layout'\n
           export default {
             // Using a render function
             layout: (h, page) => h(Layout, [page]),\n

--- a/pages/pages.mdx
+++ b/pages/pages.mdx
@@ -213,7 +213,7 @@ For example, maybe you have an audio player on a podcast website that you want t
             </>
           )
         }\n
-        Home.layout = child => <Layout children={child} title="Welcome" />\n
+        Home.layout = page => <Layout children={page} title="Welcome" />\n
         export default Home
       `,
     },
@@ -270,9 +270,9 @@ You can also create more complex layout arrangements using nested layouts.
             </>
           )
         }\n
-        Home.layout = child => (
+        Home.layout = page => (
           <SiteLayout title="Welcome">
-            <NestedLayout children={child} />
+            <NestedLayout children={page} />
           </SiteLayout>
         )\n
         export default Home


### PR DESCRIPTION
This PR makes a number of improvements to the [pages](https://inertiajs.com/pages) docs.

- Shows two approaches to persistent layouts in Vue.js in the simple example.
- Removes all the aliased imports.
- Adds the new React persistent layouts documentation ([see here](https://github.com/inertiajs/inertia-react/pull/51)).
- Add title and meta tags documentation.