### PR TITLE
Fix typo on the partial reloads code example

### DIFF
--- a/pages/the-protocol.mdx
+++ b/pages/the-protocol.mdx
@@ -176,7 +176,7 @@ The `X-Inertia-Partial-Component` header includes the name of the component that
       language: 'js',
       code: dedent`
         {
-          "component": "Event",
+          "component": "Events",
           "props": {
             /*
               NOT INCLUDED:


### PR DESCRIPTION
According to the request in the same example, the component name is `Events`, but the responses' component was `Event`.