### PR TITLE
Update Laravel examples

### DIFF
--- a/pages/responses.mdx
+++ b/pages/responses.mdx
@@ -89,13 +89,12 @@ When using [partial reloads](/requests#partial-reloads) it's best to wrap the pr
                     // Lazily evaluated (only run if required)
                     'companies' => function () {
                         return Company::orderBy('name')
-                            ->get()
-                            ->only('id', 'name');
+                            ->get('id', 'name');
                     },
                     // Evaluated immediately
                     'users' => User::orderBy('name')
-                        ->paginate()
-                        ->only('id', 'name'),
+                        ->select('id', 'name')
+                        ->paginate(),
                 ]);
             }
         }


### PR DESCRIPTION
The Laravel examples called `->only()` after fetching the results from the Database. In a Laravel stock install it would forward the call to the fetched collection where the `->only()` method filters the collection's items with the specified keys, often leading to an empty collection.

This snippet might have got in the docs due to the example app (PingCRM) uses a custom Paginator that have a `->only()` method that behaves differently than a Laravel stock install:

https://github.com/inertiajs/pingcrm/blob/master/app/Providers/AppServiceProvider.php#L84-L89

I changed the snippet in the docs because it could lead to confusion on usage as I believe was the root cause for this issue in the inertia-laravel repo:

https://github.com/inertiajs/inertia-laravel/issues/96

The easiest way to keep the snippets concise was to tell the query builder to fetch only the wanted columns. If you prefer to transform the collection after fetching from DB please let me know and I updated the PR, or if you find it faster please open a new PR with the desired approach.