### PR TITLE
Return `undefined` from useEffect

### DIFF
--- a/pages/pages.mdx
+++ b/pages/pages.mdx
@@ -127,7 +127,9 @@ While not required, for most projects it makes sense to create a site layout tha
         import React, { useEffect } from 'react'
         import { InertiaLink } from '@inertiajs/inertia-react'\n
         export default function Layout({ title, children }) {
-          useEffect(() => document.title = title, [title])\n
+          useEffect(() => {
+            document.title = title;
+          }, [title])\n
           return (
             <main>
               <header>


### PR DESCRIPTION
Using arrow function shorthand will return the `document.title` value. Which throws a React warning.

`
Warning: An effect function must not return anything besides a function, which is used for clean-up. You returned: XYZ
    in Layout (created by Inertia)
    in Inertia
`