### PR TITLE
Add ColdBox references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7783,7 +7783,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7801,11 +7802,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7818,15 +7821,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7929,7 +7935,8 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7939,6 +7946,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7951,17 +7959,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7978,6 +7989,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8058,7 +8070,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8068,6 +8081,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8143,7 +8157,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8173,6 +8188,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8190,6 +8206,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8228,11 +8245,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },

--- a/pages/asset-versioning.mdx
+++ b/pages/asset-versioning.mdx
@@ -54,6 +54,28 @@ To enable automatic asset refreshing, you simply need to tell Inertia what the c
         end
       `,
     },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        // config/ColdBox.cfc
+        component {
+            function configure() {
+                moduleSettings = {
+                    "cbInertia": {
+                        "version": function() {
+                            // If you're using ColdBox Elixir, you can
+                            // use the rev-manifest.json for this.
+                            return hash(
+                                fileRead( "/includes/rev-manifest.json" )
+                            );
+                        }
+                    }
+                };
+            }
+        }
+      `,
+    },
   ]}
 />
 

--- a/pages/demo-application.mdx
+++ b/pages/demo-application.mdx
@@ -26,3 +26,4 @@ Beyond our official demo app, Ping CRM has also been translated into numerous di
 - [Ruby on Rails/Vue.js](https://github.com/ledermann/pingcrm/) by Georg Ledermann
 - [Laravel/React](https://github.com/Landish/pingcrm-react) by Lado Lomidze
 - [Laravel/Svelte](https://github.com/zgabievi/pingcrm-svelte) by Zura Gabievi
+- [ColdBox/Vue.js](https://github.com/elpete/pingcrm-coldbox) by Eric Peterson

--- a/pages/error-handling.mdx
+++ b/pages/error-handling.mdx
@@ -64,6 +64,13 @@ In production you'll want to return a proper Inertia error response instead of r
         # todo
       `,
     },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        // todo
+      `,
+    },
   ]}
 />
 

--- a/pages/forms.mdx
+++ b/pages/forms.mdx
@@ -168,6 +168,44 @@ Unlike a classic ajax submitted form, with Inertia you don't handle the post sub
         end
       `,
     },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        component name="users" {\n
+            property name="inertia" inject="@cbInertia";
+            property name="userService" inject="quickService:User";\n
+            function index( event, rc, prc ) {
+                return inertia( "Users/Index", {
+                    "users": userService.all()
+                        .map( function( user ) {
+                            return user.getMemento();
+                        } )
+                } );
+            }\n
+            function store( event, rc, prc ) {
+                userService.create(
+                    validateOrFail( target = rc, constraints = {
+                        "first_name": {
+                            "required": true,
+                            "max": 50
+                        },
+                        "last_name": {
+                            "required": true,
+                            "max": 50
+                        },
+                        "email": {
+                            "required": true,
+                            "max": 50 ,
+                            "type": "email"
+                        },
+                    } )
+                );\n
+                relocate( "users" );
+            }
+        }
+      `,
+    },
   ]}
 />
 
@@ -202,6 +240,24 @@ From there you need to send those error messages to your form page component. Yo
       code: dedent`
         # todo
       `,
+    },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        component {\n
+            property name="inertia" inject="provider:@cbInertia";
+            property name="flash" inject="coldbox:flash";\n
+            function preProcess( event ) {
+                inertia.share( {
+                    "errors": function() {
+                        return flash.get( "errors", {} );
+                    }
+                } );
+            }\n
+        }
+      `,
+      description: 'Place this code in a registered preProcess interceptor.',
     },
   ]}
 />
@@ -328,7 +384,7 @@ While this is very similar to how you would normally do classic server-side form
 
 ## File uploads
 
-The trick to uploading files with Inertia (via XHR) is using the `FormData` object. Here is a simple example of using `FormData` with Inertia.
+The trick to uploading files with Inertia (via XHR) is using the `FormData` object. Here is a simple example of using `FormData` with Inertia.
 
 ```js
 var data = new FormData()

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -26,7 +26,7 @@ See the [who is it for](/who-is-it-for) and [how it works](/how-it-works) pages 
 
 ## Not a framework
 
-Inertia isn't a framework, nor is it a replacement to your existing server-side or client-side frameworks. Rather, it's designed to work with them. Think of Inertia as glue that connects the two. Inertia does this via adapters. We currently have three official client-side adapters (React, Vue.js, and Svelte) and two server-side adapters (Laravel and Rails).
+Inertia isn't a framework, nor is it a replacement to your existing server-side or client-side frameworks. Rather, it's designed to work with them. Think of Inertia as glue that connects the two. Inertia does this via adapters. We currently have three official client-side adapters (React, Vue.js, and Svelte) and three server-side adapters (Laravel, Rails, and ColdBox).
 
 ## Join the newsletter
 

--- a/pages/installation.mdx
+++ b/pages/installation.mdx
@@ -22,6 +22,7 @@ To use Inertia you need both a server-side adapter as well as a client-side adap
 - [Svelte](https://github.com/inertiajs/inertia-svelte)
 - [Laravel](https://github.com/inertiajs/inertia-laravel)
 - [Rails](https://github.com/inertiajs/inertia-rails)
+- [ColdBox](https://github.com/elpete/cbInertia)
 
 ## Server-side setup
 

--- a/pages/redirects.mdx
+++ b/pages/redirects.mdx
@@ -5,7 +5,10 @@ import TabbedCodeExamples from '../components/TabbedCodeExamples'
 export default Layout
 export const meta = {
   title: 'Redirects',
-  links: [{ url: '#top', name: 'Making redirects' }, { url: '#303-response-code', name: '303 response code' }],
+  links: [
+    { url: '#top', name: 'Making redirects' },
+    { url: '#303-response-code', name: '303 response code' },
+  ],
 }
 
 # Redirects
@@ -56,6 +59,33 @@ Inertia will automatically follow this redirect and update the page accordingly.
             redirect_to users_path
           end
         end
+      `,
+    },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        component name="users" {\n
+            property name="inertia" inject="@cbInertia";
+            property name="userService" inject="quickService:User";\n
+            function index( event, rc, prc ) {
+                return inertia( "Users/Index", {
+                    "users": userService.all().map( function( user ) {
+                        return user.getMemento();
+                    } );
+                } );
+            }\n
+            function store( event, rc, prc ) {
+                userService.create(
+                    validateOrFail( target = rc, constraints = {
+                        "first_name": { "required": true, "max": 50 },
+                        "last_name": { "required": true, "max": 50 },
+                        "email": { "required": true, "max": 50 , "type": "email" },
+                    } )
+                );\n
+                relocate( "users" );
+            }
+        }
       `,
     },
   ]}

--- a/pages/responses.mdx
+++ b/pages/responses.mdx
@@ -63,6 +63,26 @@ In this example we're passing a single prop, called `event`, which contains four
       `,
       description: `To make an Inertia response, use the inertia renderer. This renderer takes the component name, and allows you to pass props and view_data as an options hash.`,
     },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        component name="events" {\n
+            property name="inertia" inject="@cbInertia";\n
+            function show( event, rc, prc ) {
+                inertia.render( "Event/Show", {
+                    "event": event.getOnly( [
+                        "id",
+                        "title",
+                        "start_date",
+                        "description"
+                    ] )
+                } );
+            }
+        }
+      `,
+      description: `To make an Inertia response, use the Inertia render function or the inertia() shorthand. This method takes the component name, and allows you to pass props.`,
+    },
   ]}
 />
 
@@ -112,8 +132,7 @@ When using [partial reloads](/requests#partial-reloads) it's best to wrap the pr
                 Company.
                   order(:name).
                   as_json(only: [ :id, :name ])
-              },
-              
+              },\n
               # Evaluated immediately
               users: User.
                 order(:name).
@@ -122,6 +141,30 @@ When using [partial reloads](/requests#partial-reloads) it's best to wrap the pr
             }
           end
         end
+      `,
+    },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        component name="users" {\n
+            property name="inertia" inject="@cbInertia";
+            property name="userService" inject="quickService:User";
+            property name="companyService" inject="quickService:Company";\n
+            function index( event, rc, prc ) {
+                inertia.render( "Users/Index", {
+                    // Lazily evaluated (only run if required)
+                    "companies": function () {
+                        return companySerivce.orderBy( "name" )
+                            .get( [ "id", "name" ] );
+                    },
+                    // Evaluated immediately
+                    "users": userService.orderBy( "name" )
+                        .select( [ "id", "name" ] )
+                        .paginate()
+                } );
+            }
+        }
       `,
     },
   ]}
@@ -149,6 +192,14 @@ There are situations where you may want to access your prop data in your root Bl
       `,
       description: `These props are available via the page variable.`,
     },
+    {
+      name: 'ColdBox',
+      language: 'markup',
+      code: dedent`
+        <meta name="twitter:title" content="#prc.inertia__page.props.event.title#">
+      `,
+      description: `These props are available via the inertia__page variable in the prc scope.`,
+    },
   ]}
 />
 
@@ -173,6 +224,15 @@ Sometimes you may even want to provide data that will not be sent to your JavaSc
       `,
       description: `Do this using the "view_data" option`,
     },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        prc.meta = myEvent.meta;
+        inertia.render( "Event", { "event": myEvent } );
+      `,
+      description: `Anything in the rc or prc scope will be availble to your view and not the JavaScript component.`,
+    },
   ]}
 />
 
@@ -192,6 +252,13 @@ You can then access this variable like a regular template variable.
       language: 'erb',
       code: dedent`
         <meta name="description" content="<%= meta %>">
+      `,
+    },
+    {
+      name: 'ColdBox',
+      language: 'markup',
+      code: dedent`
+        <meta name="description" content="#prc.meta#">
       `,
     },
   ]}

--- a/pages/routing.mdx
+++ b/pages/routing.mdx
@@ -5,7 +5,10 @@ import TabbedCodeExamples from '../components/TabbedCodeExamples'
 export default Layout
 export const meta = {
   title: 'Routing',
-  links: [{ url: '#top', name: 'Defining routes' }, { url: '#generating-routes', name: 'Generating URLs' }],
+  links: [
+    { url: '#top', name: 'Defining routes' },
+    { url: '#generating-routes', name: 'Generating URLs' },
+  ],
 }
 
 # Routing
@@ -43,7 +46,7 @@ The first option is to generate URLs server-side and include them as props. Noti
                 ]);
             }
         }
-      `
+      `,
     },
     {
       name: 'Rails',
@@ -63,7 +66,30 @@ The first option is to generate URLs server-side and include them as props. Noti
             }
           end
         end
-      `
+      `,
+    },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        component name="users" {\n
+            property name="inertia" inject="@cbInertia";
+            property name="userService" inject="quickService:User";\n
+            function index( event, rc, prc ) {
+                inertia.render( "Users/Index", {
+                    "users": userService.all().map( function( user ) {
+                        return {
+                            "id": user.getId(),
+                            "name": user.getName(),
+                            "email": user.getEmail(),
+                            "edit_url": "/users/#user.getId()#/edit",
+                        };
+                    } ),
+                    "create_url": "/users/create",
+                } );
+            }
+        }
+      `,
     },
   ]}
 />

--- a/pages/security.mdx
+++ b/pages/security.mdx
@@ -77,6 +77,13 @@ With Inertia, authorization is best handled server-side in your policies. Howeve
         end
       `,
     },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        // todo
+      `,
+    },
   ]}
 />
 

--- a/pages/server-side-setup.mdx
+++ b/pages/server-side-setup.mdx
@@ -37,6 +37,14 @@ Install the Inertia server-side adapters using the preferred package manager for
         gem 'inertia_rails'
       `,
     },
+    {
+      name: 'ColdBox',
+      language: 'bash',
+      code: dedent`
+        box install cbInertia
+      `,
+      description: 'Install via CommandBox and ForgeBox',
+    },
   ]}
 />
 
@@ -75,6 +83,32 @@ Next, setup the root template that will be loaded on the first page visit. This 
       `,
       description: `Inertia Rails automatically uses your default application layout. If you'd like to change that, you can do so via the Inertia config.`,
     },
+    {
+      name: 'ColdBox',
+      language: 'markup',
+      code: dedent`
+        <cfoutput>
+        <!DOCTYPE html>
+        <html class="h-full bg-grey-lighter">
+        <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+            <title>Quick Tailwind Inertia Template</title>
+            <link rel="stylesheet" href="#html.elixirPath( "/css/app.css" )#">
+        </head>
+        <body class="font-sans leading-none text-grey-darkest antialiased">
+            <div>
+                #renderView()#
+            </div>
+            <script src="#html.elixirPath( "/js/runtime.js" )#"></script>
+            <script src="#html.elixirPath( "/js/vendor.js" )#"></script>
+            <script src="#html.elixirPath( "/js/app.js" )#"></script>
+        </body>
+        </html>
+        </cfoutput>
+      `,
+      description: `By default the ColdBox adapter will set the view to cbInertia:main.index. Your layout should include your assets and a renderView call. cbInertia will insert the required view automatically.`,
+    },
   ]}
 />
 
@@ -98,6 +132,24 @@ While not required, it's highly recommended that you also configure automatic as
         InertiaRails.configure do |config|
           config.version = '1.0'
         end
+      `,
+    },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        // config/ColdBox.cfc
+        component {
+            function configure() {
+                moduleSettings = {
+                    "cbInertia": {
+                        "version": function() {
+                            return "1.0.0";
+                        }
+                    }
+                };
+            }
+        }
       `,
     },
   ]}
@@ -146,6 +198,23 @@ That's it, you're all ready to go server-side! From here you can start creating 
               }
           end
         end
+      `,
+    },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        component name="events" {\n
+            property name="inertia" inject="@cbInertia";
+            property name="eventService" inject="quickService:Event";\n
+            function show( event, rc, prc ) {
+                inertia.render( "Event/Show", {
+                    "event": eventService
+                        .findOrFail( rc.id )
+                        .getMemento()
+                } );
+            }
+        }
       `,
     },
   ]}

--- a/pages/shared-data.mdx
+++ b/pages/shared-data.mdx
@@ -78,6 +78,42 @@ The server-side adapters provide a way to preassign shared data for each request
         inertia_share user_count: lambda { User.count }
       `,
     },
+    {
+      name: 'ColdBox',
+      language: 'javascript',
+      code: dedent`
+        // Synchronously
+        inertia.share( "app.name", getSetting( "appName" ) );\n
+        // Lazily
+        inertia.share( "auth.user", function () {
+            if ( auth().check() ) {
+                return {
+                    "id": auth().user().getId(),
+                    "first_name": auth().user().getFirstName(),
+                    "last_name": auth().user().getLastName()
+                };
+            }
+        } );\n
+        // Multiple values
+        inertia.share( {
+            // Synchronously
+            "app": {
+                "name": getSetting( "appName" )
+            },
+            // Lazily
+            "auth": function() {
+                if ( auth().check() ) {
+                    return {
+                        "id": auth().user().getId(),
+                        "first_name": auth().user().getFirstName(),
+                        "last_name": auth().user().getLastName()
+                    };
+                }
+            }
+        } );
+      `,
+      description: 'Place this code in a registered preProcess interceptor.',
+    },
   ]}
 />
 
@@ -199,6 +235,18 @@ Here's a simple way to implement flash messages in your Inertia applications. Fi
             }
           }
         end
+      `,
+    },
+    {
+      name: 'ColdBox',
+      description: 'Place this code in a registered preProcess interceptor.',
+      language: 'javascript',
+      code: dedent`
+        inertia.share( "flash", function() {
+            return {
+                "message": flash.get( "message", "" )
+            };
+        } );
       `,
     },
   ]}

--- a/pages/who-is-it-for.mdx
+++ b/pages/who-is-it-for.mdx
@@ -10,7 +10,7 @@ export const meta = {
 
 # Who is Inertia.js for?
 
-Inertia was designed for development teams who typically build server-side rendered applications using frameworks like Laravel, Ruby on Rails or Django. They create controllers, get data from the database (via an ORM), and render views.
+Inertia was designed for development teams who typically build server-side rendered applications using frameworks like Laravel, Ruby on Rails, ColdBox, or Django. They create controllers, get data from the database (via an ORM), and render views.
 
 But what happens when these developers want to replace their server-side rendered views with a modern JavaScript-based single-page app front-end? The answer is always "you need to build an API". Because that's how modern SPAs are built.
 


### PR DESCRIPTION
[ColdBox](https://coldbox.org/) is a modern MVC framework developed by [Ortus Solutions](https://www.ortussolutions.com/) and built on CFML engines like [ColdFusion](https://www.adobe.com/products/coldfusion-family.html) and [Lucee](https://lucee.org/).

At Ortus, we're big fans of Laravel, and often take inspiration from it.  So when you announced Inertia.js, we knew we wanted to make an official adapter for it.

You can find the ColdBox adapter for Inertia.js [here](https://github.com/elpete/cbInertia).  It's called `cbInertia`.  We'd love to add it here as an official Inertia.js server-side adapter.

Let me know if you'd like anything changed.  And thank you so much for Inertia.js!