### PR TITLE
Add a community adapters section to installation

### DIFF
--- a/pages/installation.mdx
+++ b/pages/installation.mdx
@@ -6,6 +6,7 @@ export const meta = {
   links: [
     { url: '#top', name: 'Introduction' },
     { url: '#official-adapters', name: 'Official adapters' },
+    { url: '#community-adapters', name: 'Community adapters' },
     { url: '#server-side-setup', name: 'Server-side setup' },
     { url: '#client-side-setup', name: 'Client-side setup' },
   ],
@@ -22,6 +23,14 @@ To use Inertia you need both a server-side adapter as well as a client-side adap
 - [Svelte](https://github.com/inertiajs/inertia-svelte)
 - [Laravel](https://github.com/inertiajs/inertia-laravel)
 - [Rails](https://github.com/inertiajs/inertia-rails)
+
+## Community adapters
+
+Adapters for Inertia.js are also available for many other server-side and client-side frameworks from the community.
+
+- [ColdBox](https://github.com/elpete/cbInertia)
+
+If you have a community adapter you'd like to see here, [please send a Pull Request!](https://github.com/inertiajs/inertiajs.com/edit/master/pages/installation.mdx)
 
 ## Server-side setup
 


### PR DESCRIPTION
As discussed in #52, this new sections highlights other adapters that aren't maintained by the Inertia.js team but that allow you to work with Inertia using other server-side and client-side frameworks.

It also includes [ColdBox](https://github.com/elpete/cbInertia) as the first community adapter.