### PR TITLE
Add Symfony adapter to the installation page

### DIFF
--- a/pages/installation.mdx
+++ b/pages/installation.mdx
@@ -33,6 +33,7 @@ There are also numerous community built server-side adapters available. If you h
 - [AspNetCore](https://github.com/Nothing-Works/inertia-aspnetcore)
 - [Phoenix Framework](https://github.com/devato/inertia_phoenix)
 - [Yii2](https://github.com/tbreuss/yii2-inertia)
+- [Symfony](https://github.com/rompetomp/inertia-bundle)
 
 ## Server-side setup
 


### PR DESCRIPTION
My Symfony adapter has been available for a while now. I added it to the installation page.