### PR TITLE
Initialize React App only on `DOMContentLoaded`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /out
 /node_modules
 .DS_Store
+.idea

--- a/pages/client-side-setup.mdx
+++ b/pages/client-side-setup.mdx
@@ -80,14 +80,16 @@ Next, update your main JavaScript file to boot your Inertia app. All we're doing
         import { InertiaApp } from '@inertiajs/inertia-react'
         import React from 'react'
         import { render } from 'react-dom'\n
-        const app = document.getElementById('app')\n
-        render(
-          <InertiaApp
-            initialPage={JSON.parse(app.dataset.page)}
-            resolveComponent={name => require(\`./Pages/\${name}\`).default}
-          />,
-          app
-        )
+        document.addEventListener('DOMContentLoaded', () => {
+          const app = document.getElementById('app')
+          render(
+            <InertiaApp
+              initialPage={JSON.parse(app.dataset.page)}
+              resolveComponent={name => require(`./Pages/${name}`).default}
+            />,
+            app
+          )
+        })
       `,
     },
     {


### PR DESCRIPTION
Hello, 

I've started playing with Inertia Js in a Rails App that also uses React and run into a problem.

The React App was rendered before `DOMContentLoaded` was triggered and raised an error because it could not find any `div#app` .

I've fixed that on my machine and I thought I told myself that pushing this improvement to the main repository would help others.

Cheers
Dorian