### PR TITLE
Fix typo in document.

### DIFF
--- a/pages/links.mdx
+++ b/pages/links.mdx
@@ -159,7 +159,7 @@ You can preserve a page component's local state using the `preserve-state` attri
       language: 'html',
       code: dedent`
         <input onChange={this.handleChange} value={query} />
-        <InertiaLink href="/search" data={query} preserve-state>Search</InertiaLink>
+        <InertiaLink href="/search" data={query} preserveState>Search</InertiaLink>
       `,
     },
     {
@@ -190,7 +190,7 @@ By default page visits will automatically reset the scroll position back to the 
       name: 'React',
       language: 'html',
       code: dedent`
-        <InertiaLink preserve-scroll href="/">Home</InertiaLink>
+        <InertiaLink preserveScroll href="/">Home</InertiaLink>
       `,
     },
     {


### PR DESCRIPTION
Basically, **Link** component document for **React** is incorrect. 
In this [document](https://inertiajs.com/links), it said that InnertiaLink accepted `preserve-state` & `preserve-scroll`.
However, [InertiaLink t](https://github.com/inertiajs/inertia-react/blob/master/src/Link.js) actually read data from props named `preserveState` & `preserveScroll`.


