### PR TITLE
Removed X-Inertia header check

### DIFF
--- a/pages/error-handling.mdx
+++ b/pages/error-handling.mdx
@@ -46,7 +46,6 @@ In production you'll want to return a proper Inertia error response instead of r
         {
             $response = parent::render($request, $exception);\n
             if (App::environment('production')
-                && $request->header('X-Inertia')
                 && in_array($response->status(), [500, 503, 404, 403])
             ) {
                 return Inertia::render('Error', ['status' => $response->status()])


### PR DESCRIPTION
## Case
Is there any benefit in leaving this header check in the handler? In this case the only benefit of doing this check is if there's a case where you need to separate the vanilla errors from the ones that occur from inertia requests. This seems like an edge-case to, no?

## Benefits
### Removes code-duplication
Since both vanilla requests and inertia requests can share the same views there is no need for code duplication. So instead of having a blade views for error handling _and_ the same for vue/react/svelte we are instead left with error handling using only vue/react/svelte.

## Drawbacks

...

## In closing
This PR was prompted from a conversation with @Cannonb4ll on Discord.

Thoughts?