### PR TITLE
Added Instant form validation page

### DIFF
--- a/components/Nav.js
+++ b/components/Nav.js
@@ -171,6 +171,11 @@ export default ({ className }) => {
             <a className={linkClass('/server-side-rendering')}>Server-side rendering</a>
           </Link>
         </li>
+        <li className="md:pr-3">
+          <Link href="/instant-form-validation">
+            <a className={linkClass('/instant-form-validation')}>Instant form validation</a>
+          </Link>
+        </li>
       </ul>
     </nav>
   )

--- a/pages/instant-form-validation.mdx
+++ b/pages/instant-form-validation.mdx
@@ -1,0 +1,155 @@
+import dedent from 'dedent-js'
+import Layout from '../components/Layout'
+import TabbedCodeExamples from '../components/TabbedCodeExamples'
+
+export default Layout
+export const meta = {
+  title: 'Instant form validation',
+  links: [{ url: '#top', name: 'Introduction' }, { url: '#setup-client-side', name: 'Setup client side' }, { url: '#setup-server-side', name: 'Setup server side' }],
+}
+
+# Instant form validation
+
+Validation in Inertia.js works out of the box as you'd expect. 
+
+However, you might want a more reactive validation to your form requests.
+
+Enter; instant form validations!
+
+<div className="my-6 relative rounded overflow-hidden bg-gray-500" style={{ paddingTop: '65.5%' }}>
+  <div className="absolute inset-0 w-full h-full flex items-center justify-center text-sm">Loading&hellip;</div>
+  <iframe
+    className="absolute inset-0 w-full h-full"
+    src="https://player.vimeo.com/video/441572812?autoplay=1&loop=1&muted=1&background=1"
+  ></iframe>
+</div>
+
+## Setup client side
+
+We need to pass a flag to the server side indicating when we want to validate only. If we don't do this, then the data will instantly be saved when the validation passes. Note the `validate` property set to `true` as the second argument for the `this.$inertia.post()` method.
+
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Vue',
+      language: 'twig',
+      code: dedent`
+      <script>
+        export default {
+          watch: {
+            form: {
+              handler: function() {
+                this.$inertia.post('organizations', {...this.form, validate: true});
+              },
+              deep: true,
+            },
+          }
+        }
+      </script>
+      `,
+    },
+    {
+      name: 'React',
+      language: 'html',
+      code: dedent`
+        https://reactjs.org/docs/forms.html#handling-multiple-inputs
+      `,
+    },
+    {
+      name: 'Svelte',
+      language: 'html',
+      code: dedent`
+        https://github.com/sveltejs/svelte/issues/2727#issuecomment-493486681
+      `,
+    },
+  ]}
+/>
+
+It is recommended to using something like the [lodash `debounce`](https://lodash.com/docs/4.17.15#debounce) function as to not send a request for every keystroke.
+## Setup server side
+
+Making use of instant form validation requires us to create what is referred to as a [“form request”](https://laravel.com/docs/7.x/validation#form-request-validation) in Laravel.
+
+These form requests have a `passedValidation` method that we can override.
+
+We check for the validate parameter being passed. 
+
+The `get` method on the `request` object takes an optional default value as a second parameter. [(`public function get($key, $default = null)`)](https://github.com/symfony/symfony/blob/5.0/src/Symfony/Component/HttpFoundation/ParameterBag.php#L67-L77)
+
+If we are only validating the request, then we will throw a [`ValidatedException`](/instant-form-validation#validated-exception).
+
+### Custom Form Request
+
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Laravel',
+      language: 'php',
+      code: dedent`
+      namespace App\\Http\\Requests;\n
+      use Illuminate\\Foundation\\Http\\FormRequest;\n
+      class CustomFormRequest extends FormRequest
+      {
+          /**
+           * Get the validation rules that apply to the request.
+           *
+           * @return array
+           */
+          public function rules()
+          {
+              return [
+                  // Your validation rules here
+              ];
+          }\n
+          /**
+           * Handle a passed validation attempt.
+           *
+           * @return void
+           */
+          public function passedValidation()
+          {
+              if ($this->request->get('validate', false)) {
+                  throw new \\App\\Exceptions\\ValidatedException();
+              }
+          }
+      }
+      `,
+    }
+  ]}
+/>
+
+### ValidatedException
+
+In this validation exception we redirect back to the route where the form is, like we do after we've stored data, the difference being that we didn't store anything.
+
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Laravel',
+      language: 'php',
+      code: dedent`
+    namespace App\\Exceptions;\n
+    use Exception;
+    use Illuminate\\Http\\Request;
+    use Illuminate\\Support\\Facades\\Redirect;\n
+    class ValidatedException extends Exception
+    {
+        /**
+         * Render the exception into an HTTP response.
+         *
+         * @param  \\Illuminate\\Http\\Request  $request
+         * @return \\Illuminate\\Http\\Response
+         */
+        public function render(Request $request)
+        {
+            return Redirect::back();
+        }
+    }
+      `,
+    }
+  ]}
+/>
+
+## Conclusion
+
+That's it, you're ready to get your forms validated instantly!


### PR DESCRIPTION
I hacked away at a way for allowing instant form validation a couple weeks ago and thought I'd contribute my findings in the form of a page on the documentation.

 # Summary

Basically, a watcher is attached to the form on the client-side, sending a request to the route which is used for storing the resource with an extra `validate` parameter.

The `validate` parameter is checked for in the form request in the `passedValidation()` method, and raises an exception, which is caught, and finally just redirects the request back.
```php
<?php

namespace App\Http\Requests;

use App\Exceptions\ValidatedException;
use Illuminate\Foundation\Http\FormRequest;

class CustomFormRequest extends FormRequest
{
    /**
     * Handle a passed validation attempt.
     *
     * @return void
     */
    public function passedValidation()
    {
        if ($this->request->get('validate', false)) {
            throw new ValidatedException();
        }
    }
}
```
```php
<?php

namespace App\Exceptions;

use Exception;
use Illuminate\Support\Facades\Redirect;

class ValidatedException extends Exception
{
    public function render()
    {
        return Redirect::back();
    }
}

```

The controller code is no different than any other custom form request, it all happens very much in the background.

```php
<?php

namespace App\Http\Controllers;

use App\Http\Requests\CustomFormRequest;
use App\Organization;
use Illuminate\Support\Facades\Auth;
use Illuminate\Support\Facades\Redirect;
use Illuminate\Support\Facades\Request;
use Inertia\Inertia;

class OrganizationsController extends Controller
{
    public function store(CustomFormRequest $request)
    {
        Auth::user()->account->organizations()->create(
            $request->validated()
        );

        return Redirect::route('organizations')->with('success', 'Organization created.');
    }
}
```
## React & Svelte
I found some examples of doing this in react and svelte. @sebastiandedeyne & @pedroborges could you guys sign off on these being appropriate replacements for using watchers in vue?

https://reactjs.org/docs/forms.html#handling-multiple-inputs
https://github.com/sveltejs/svelte/issues/2727#issuecomment-493486681

## Rails
@bknoles Is there something similar that we can do in Rails to accomplish this? I skimmed through the documentation but couldn't find anything similar to a `passedValidation()` method, unfortunately.