### PR TITLE
Update Example Laravel Error Handling Code Snip

### DIFF
--- a/pages/error-handling.mdx
+++ b/pages/error-handling.mdx
@@ -46,7 +46,6 @@ In production you'll want to return a proper Inertia error response instead of r
         {
             $response = parent::render($request, $exception);\n
             if (App::environment('production')
-                && $request->header('X-Inertia')
                 && in_array($response->status(), [500, 503, 404, 403])
             ) {
                 return Inertia::render('Error', ['status' => $response->status()])


### PR DESCRIPTION
Wondering if this small change to the example Laravel error handling is suitable for the majority of use cases.  I've found it to be the simpler solution for me.

If you are conditionally checking for an Inertia request, then the Vue based error page is only rendered when the request is an Inertia request.  If the page was manually reloaded, and the request were to come through as a normal browser request, Laravel would fall back to serving the blade based 404.blade.php view.  If we remove the check for an Inertia request then the Vue based error page is always served.  This way we only need to maintain one template.