### PR TITLE
docs(installation): fix links to archived repositories

### DIFF
--- a/pages/installation.mdx
+++ b/pages/installation.mdx
@@ -18,9 +18,9 @@ To use Inertia you need both a server-side adapter as well as a client-side adap
 
 ## Official adapters
 
-- [React](https://github.com/inertiajs/inertia-react)
-- [Vue.js](https://github.com/inertiajs/inertia-vue)
-- [Svelte](https://github.com/inertiajs/inertia-svelte)
+- [React](https://github.com/inertiajs/inertia/tree/master/packages/inertia-react)
+- [Vue.js](https://github.com/inertiajs/inertia/tree/master/packages/inertia-vue)
+- [Svelte](https://github.com/inertiajs/inertia/tree/master/packages/inertia-svelte)
 - [Laravel](https://github.com/inertiajs/inertia-laravel)
 - [Rails](https://github.com/inertiajs/inertia-rails)
 


### PR DESCRIPTION
The links on the installation page were leading to the archived repositories of the front-end adapters.