### PR TITLE
feat: Add state for tabbed code examples

### DIFF
--- a/components/TabbedCodeExamples.js
+++ b/components/TabbedCodeExamples.js
@@ -28,15 +28,15 @@ export default ({ className, examples, height }) => {
 
   useEffect(() => {
     let hash = window.location.hash;
+    hash = hash.length > 1 ? hash.substr(1) : window.localStorage.getItem('inertia.activeTab');
 
     if (hash) {
-      hash = hash.substr(1);
       let hashIndex = examples.findIndex(example => example.name.toLowerCase() == hash.toLowerCase());
 
       if (hashIndex >= 0) {
-        return setTabHash(hash);
+        setHash(hash);
+        setTabHash(hash);
       }
-
     }
   }, []);
 
@@ -47,10 +47,15 @@ export default ({ className, examples, height }) => {
     setActiveTab(index);
   }, [tabHash]);
 
+  const setHash = (hash) => {
+    window.location.hash = '#' + hash;
+    window.localStorage.setItem('inertia.activeTab', hash);
+  }
+
   const setTab = (tabIndex) => {
     let hash = examples[tabIndex].name.toLowerCase();
-    window.location.hash = '#' + hash;
 
+    setHash(hash);
     setTabHash(hash);
   }
 


### PR DESCRIPTION
Hey,

someone in the Discord asked for the functionality to set the tabbed code examples by URL hash  and I thought it sounds quite useful.

> While writing this article, I had the urge to put links directly to code snippets of React on Inertia website. But React components are on "second" tab. Looking at code of website, these tabs are based on "index". 
> Any ideas how it can be made to also work with # from url??
> For example, if I put https://inertiajs.com/client-side-setup#react then React code tabs should be active? Thoughts?

I am not familiar with React, but after some time and googling I managed to create the following functionality:

1) Toggling the code examples will toggle all code examples on the page.
2) The lowercase name of the examples will be appended as a hash.
3) The lowercase name of the examples will be stored in localStorage.
4) When loading the page, code examples matching the hash will be activated.
5) When no example matches the hash, the first example will be used as fallback.

Maybe someone with better React skills could review this. Also I wasn't sure whether I should extract the `globalState` functions into a separate file. But I didn't want to create a new `helpers` folder for only one file and since it's not reused I kept it with the `TabbedCodeExamples.vue` file.

Downsides:
1) Doesn't work together with anchor links.
2) Some pages have frontend and backend examples.

Here's a quick demo: https://www.loom.com/share/9456c8a80b2a4e989cfed0a1b0f32222

Cheers

