### PR TITLE
Adds Context and LocalStorage implementation to remember User framework choice

### DIFF
--- a/components/TabbedCodeExamples.js
+++ b/components/TabbedCodeExamples.js
@@ -1,35 +1,58 @@
 import Code from './Code'
-import React, { useState } from 'react'
+import React, { useState, useContext, useEffect } from 'react'
+import { FrontendFrameworkContext } from '../context/FrontendFrameworkProvider'
+import { BackendFrameworkContext } from '../context/BackendFrameworkProvider'
 
-export default ({ className, examples, height }) => {
+export default ({ className, snippets, height, type }) => {
+
+  const { frontendFramework, setFrontendFramework } = useContext(FrontendFrameworkContext)
+  const { backendFramework, setBackendFramework } = useContext(BackendFrameworkContext)
+
   const [activeTab, setActiveTab] = useState(0)
+
+  useEffect(() => {
+    const frameworkIndex = type === 'frontend' ? frontndFrameworkIndex() : backendFrameworkIndex()
+    setActiveTab(frameworkIndex)
+  }, [frontendFramework, backendFramework])
+
+  const handleTabClick = (snippet) => {
+    type === 'frontend' ? setFrontendFramework(snippet.framework) : setBackendFramework(snippet.framework)
+  }
+
+  const frontndFrameworkIndex = () => {
+    return snippets.findIndex((e) => e.framework === frontendFramework)
+  }
+
+  const backendFrameworkIndex = () => {
+    return snippets.findIndex((e) => e.framework === backendFramework)
+  }
 
   return (
     <div className={className}>
       <div className="px-4 pt-3 flex" css={{ background: '#303f6d' }}>
-        {examples.map((example, index) => (
-          <button
+        {snippets.map((snippet, index) => (
+          <a
             key={index}
             type="button"
-            onClick={() => setActiveTab(index)}
-            className="focus:outline-none text-sm text-gray-500 hover:text-gray-200 font-medium px-3 sm:px-6 pt-3 pb-2 rounded-t mr-1"
+            onClick={() => handleTabClick(snippet)}
+            className="cursor-pointer focus:outline-none text-sm text-gray-500 hover:text-gray-200 font-medium px-3 sm:px-6 pt-3 pb-2 rounded-t mr-1"
             css={index === activeTab ? { color: 'white', background: '#202e59' } : {}}
           >
-            {example.name}
-          </button>
+            {snippet.name}
+          </a>
         ))}
       </div>
-      <Code className="p-6 leading-normal" language={examples[activeTab].language} height={height}>
-        {examples[activeTab].code}
+      <Code className="p-6 leading-normal" language={snippets[activeTab].language} height={height}>
+        {snippets[activeTab].code}
       </Code>
-      {examples[activeTab].description && (
+      {snippets[activeTab].description && (
         <div className="p-4 text-sm font-medium text-white flex items-baseline" css={{ background: '#303f6d' }}>
           <div className="flex-shrink-0 w-4 h-4 fill-current mr-2">
             <svg className="mt-1 w-full h-full" viewBox="0 0 20 20">
               <path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zM9 11v4h2V9H9v2zm0-6v2h2V5H9z" />
             </svg>
           </div>
-          <div className="leading-snug">{examples[activeTab].description}</div>
+          <div className="leading-snug">{snippets[activeTab].description}</div>
         </div>
       )}
     </div>

--- a/context/BackendFrameworkProvider.js
+++ b/context/BackendFrameworkProvider.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react'
+
+export const BackendFrameworkContext = React.createContext()
+
+const BackendFrameworkProvider = ({ children }) => {
+  const [backendFramework, setBackendFramework] = useState('laravel')
+
+  useEffect(() => {
+    const initialFramework = localStorage.getItem('inertia.backend.framework')
+    if (initialFramework) {
+      setBackendFramework(initialFramework)
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('inertia.backend.framework', backendFramework)
+  }, [backendFramework])
+
+  return (
+    <BackendFrameworkContext.Provider
+      value={{
+        backendFramework,
+        setBackendFramework,
+      }}
+    >
+      {children}
+    </BackendFrameworkContext.Provider>
+  )
+}
+
+export default BackendFrameworkProvider

--- a/context/FrontendFrameworkProvider.js
+++ b/context/FrontendFrameworkProvider.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react'
+
+export const FrontendFrameworkContext = React.createContext()
+
+const FrontendFrameworkProvider = ({ children }) => {
+  const [frontendFramework, setFrontendFramework] = useState('vue')
+
+  useEffect(() => {
+    const initialFramework = localStorage.getItem('inertia.frontend.framework')
+    if (initialFramework) {
+      setFrontendFramework(initialFramework)
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('inertia.frontend.framework', frontendFramework)
+  }, [frontendFramework])
+
+  return (
+    <FrontendFrameworkContext.Provider
+      value={{
+        frontendFramework,
+        setFrontendFramework,
+      }}
+    >
+      {children}
+    </FrontendFrameworkContext.Provider>
+  )
+}
+
+export default FrontendFrameworkProvider

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,12 +1,20 @@
 import React from 'react'
 import App from 'next/app'
 import '../public/tailwind.css'
+import FrontendFrameworkProvider from '../context/FrontendFrameworkProvider'
+import BackendFrameworkProvider from '../context/BackendFrameworkProvider'
 
 class MyApp extends App {
   render() {
     const { Component, pageProps } = this.props
 
-    return <Component {...pageProps} />
+    return (
+      <BackendFrameworkProvider>
+        <FrontendFrameworkProvider>
+          <Component {...pageProps} />
+        </FrontendFrameworkProvider>
+      </BackendFrameworkProvider>
+    )
   }
 }
 

--- a/pages/asset-versioning.mdx
+++ b/pages/asset-versioning.mdx
@@ -21,8 +21,10 @@ One common challenge with single-page apps is refreshing site assets when they'v
 To enable automatic asset refreshing, you simply need to tell Inertia what the current version of your assets is. This can be any `string` (letters, numbers, or a file hash), as long as it changes when your assets have been updated.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       code: dedent`
@@ -42,6 +44,7 @@ To enable automatic asset refreshing, you simply need to tell Inertia what the c
       `,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`

--- a/pages/client-side-setup.mdx
+++ b/pages/client-side-setup.mdx
@@ -21,8 +21,10 @@ export const meta = {
 Install the Inertia client-side adapters using NPM or Yarn.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue.js',
       language: 'bash',
       code: dedent`
@@ -31,6 +33,7 @@ Install the Inertia client-side adapters using NPM or Yarn.
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'bash',
       code: dedent`
@@ -39,6 +42,7 @@ Install the Inertia client-side adapters using NPM or Yarn.
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'bash',
       code: dedent`
@@ -54,8 +58,10 @@ Install the Inertia client-side adapters using NPM or Yarn.
 Next, update your main JavaScript file to boot your Inertia app. All we're doing here is initializing the client-side framework with the base Inertia page component.
 
 <TabbedCodeExamples
-  examples={[
+ type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue.js',
       language: 'js',
       code: dedent`
@@ -74,6 +80,7 @@ Next, update your main JavaScript file to boot your Inertia app. All we're doing
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code: dedent`
@@ -91,6 +98,7 @@ Next, update your main JavaScript file to boot your Inertia app. All we're doing
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'js',
       code: dedent`
@@ -147,8 +155,10 @@ Next, create a `.babelrc` file in your project with the following:
 Finally, update the `resolveComponent` callback in your app initialization to use `import` instead of `require`.
 
 <TabbedCodeExamples
-  examples={[
+ type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue.js',
       language: 'js',
       code: dedent`
@@ -167,6 +177,7 @@ Finally, update the `resolveComponent` callback in your app initialization to us
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code: dedent`
@@ -184,6 +195,7 @@ Finally, update the `resolveComponent` callback in your app initialization to us
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'js',
       code: dedent`

--- a/pages/error-handling.mdx
+++ b/pages/error-handling.mdx
@@ -34,8 +34,10 @@ Inertia solves this by showing all non-Inertia responses in a modal. Meaning you
 In production you'll want to return a proper Inertia error response instead of relying on the modal behaviour. To do this you'll need to update your framework's default exception handler to return a custom error page.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       description: 'Default Laravel location: App\\Exceptions\\Handler.php',
@@ -57,6 +59,7 @@ In production you'll want to return a proper Inertia error response instead of r
       `,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`
@@ -69,8 +72,10 @@ In production you'll want to return a proper Inertia error response instead of r
 Notice how we're returning an `Error` page component in the example above. You'll need to actually create this. Here's an example error page component you can use as a starting point.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue.js',
       language: 'twig',
       code: dedent`
@@ -108,6 +113,7 @@ Notice how we're returning an `Error` page component in the example above. You'l
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code: dedent`
@@ -135,6 +141,7 @@ Notice how we're returning an `Error` page component in the example above. You'l
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`

--- a/pages/forms.mdx
+++ b/pages/forms.mdx
@@ -20,8 +20,10 @@ export const meta = {
 While it's possible to make classic form submissions with Inertia, it's not recommended, as they cause full page reloads. Instead, it's better to intercept form submissions and then make the [request](/requests) using Inertia.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue.js',
       language: 'twig',
       code: dedent`
@@ -57,6 +59,7 @@ While it's possible to make classic form submissions with Inertia, it's not reco
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code: dedent`
@@ -95,6 +98,7 @@ While it's possible to make classic form submissions with Inertia, it's not reco
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`
@@ -126,8 +130,10 @@ While it's possible to make classic form submissions with Inertia, it's not reco
 Unlike a classic ajax submitted form, with Inertia you don't handle the post submission behaviour client-side. Rather, you do this server-side using a [redirect](/redirects). And, of course, there is nothing stopping you from redirecting right back to the page that you're on.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       code: dedent`
@@ -154,6 +160,7 @@ Unlike a classic ajax submitted form, with Inertia you don't handle the post sub
       `,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`
@@ -182,8 +189,10 @@ From there you need to send those error messages to your form page component. Yo
 Some adapters, such as the Laravel adapter (as of [v0.2.9](https://github.com/inertiajs/inertia-laravel/releases/tag/v0.2.9)), do this automatically, making the validation errors available via the `errors` prop. However, if you'd like to share them manually (maybe you'd like the errors in a different format), you can still do this:
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       code: dedent`
@@ -199,6 +208,7 @@ Some adapters, such as the Laravel adapter (as of [v0.2.9](https://github.com/in
       description: 'Place this code in your AppServiceProvider boot method.',
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`
@@ -211,8 +221,10 @@ Some adapters, such as the Laravel adapter (as of [v0.2.9](https://github.com/in
 Now the validation errors will be available as part of your page props, and since they are reactive your template will automatically display them. Here's an updated version of the form example above that displays server-side validation errors.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue.js',
       language: 'twig',
       code: dedent`
@@ -252,6 +264,7 @@ Now the validation errors will be available as part of your page props, and sinc
       description: `In Vue page props are also available via the $page property.`,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code: dedent`
@@ -293,6 +306,7 @@ Now the validation errors will be available as part of your page props, and sinc
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`

--- a/pages/links.mdx
+++ b/pages/links.mdx
@@ -25,8 +25,10 @@ To create links within an Inertia app you'll need to use the Inertia link compon
 To create an Inertia link, use the Inertia link component. Note, any attributes you provide will be proxied to the underlying `<a>` tag.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -34,6 +36,7 @@ To create an Inertia link, use the Inertia link component. Note, any attributes 
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'html',
       code: dedent`
@@ -41,6 +44,7 @@ To create an Inertia link, use the Inertia link component. Note, any attributes 
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`
@@ -55,8 +59,10 @@ To create an Inertia link, use the Inertia link component. Note, any attributes 
 You can specify the method for an Inertia link request. The default is `GET`, but you can also use `POST`, `PUT`, `PATCH`, and `DELETE`.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -64,6 +70,7 @@ You can specify the method for an Inertia link request. The default is `GET`, bu
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'html',
       code: dedent`
@@ -71,6 +78,7 @@ You can specify the method for an Inertia link request. The default is `GET`, bu
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`
@@ -80,13 +88,16 @@ You can specify the method for an Inertia link request. The default is `GET`, bu
   ]}
 />
 
+
 ## Data
 
 You can add data using the `data` attribute. This can be an `object`, or a `FormData` instance.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -94,6 +105,7 @@ You can add data using the `data` attribute. This can be an `object`, or a `Form
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'html',
       code: dedent`
@@ -101,6 +113,7 @@ You can add data using the `data` attribute. This can be an `object`, or a `Form
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`
@@ -110,13 +123,16 @@ You can add data using the `data` attribute. This can be an `object`, or a `Form
   ]}
 />
 
+
 ## Replace
 
 You can specify the browser history behaviour. By default page visits push (new) state (`window.history.pushState`) into the history, however it's also possible to replace state (`window.history.replaceState`) by setting the `replace` attribute to true. This will cause the visit to replace the current history state, instead of adding a new history state to the stack.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -124,6 +140,7 @@ You can specify the browser history behaviour. By default page visits push (new)
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'html',
       code: dedent`
@@ -131,6 +148,7 @@ You can specify the browser history behaviour. By default page visits push (new)
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`
@@ -140,13 +158,16 @@ You can specify the browser history behaviour. By default page visits push (new)
   ]}
 />
 
+
 ## Preserve state
 
 You can preserve a page component's local state using the `preserve-state` attribute. This will prevent a page component from fully re-rendering. This is especially helpful with forms, since you can avoid manually repopulating input fields, and can also maintain a focused input.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -155,6 +176,7 @@ You can preserve a page component's local state using the `preserve-state` attri
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'html',
       code: dedent`
@@ -163,6 +185,7 @@ You can preserve a page component's local state using the `preserve-state` attri
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`
@@ -173,13 +196,16 @@ You can preserve a page component's local state using the `preserve-state` attri
   ]}
 />
 
+
 ## Preserve scroll
 
 By default page visits will automatically reset the scroll position back to the top of the page (and any [scroll regions](/pages#scroll-regions) you've defined). You can use the `preserve-scroll` attribute to disable this behaviour.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -187,6 +213,7 @@ By default page visits will automatically reset the scroll position back to the 
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'html',
       code: dedent`
@@ -194,6 +221,7 @@ By default page visits will automatically reset the scroll position back to the 
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`
@@ -203,13 +231,16 @@ By default page visits will automatically reset the scroll position back to the 
   ]}
 />
 
+
 ## Partial reloads
 
 The `only` option allows you to request a subset of the props (data) from the server on subsequent visits to the _same page_. This feature is called partial reloads, and can be a helpful performance optimization if it's acceptable that some page data becomes stale. For partial reloads to be effective, be sure to use [lazy evaluation](/responses#lazy-evaluation) server-side.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -217,6 +248,7 @@ The `only` option allows you to request a subset of the props (data) from the se
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'html',
       code: dedent`
@@ -224,6 +256,7 @@ The `only` option allows you to request a subset of the props (data) from the se
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`

--- a/pages/local-state-caching.mdx
+++ b/pages/local-state-caching.mdx
@@ -23,8 +23,10 @@ For example, if a user partially completes a form, then navigates away, and then
 To mitigate this issue, you can tell Inertia which local component state to cache in the browser history.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       description: 'Use the "remember" property to cache local state.',
       language: 'js',
@@ -51,6 +53,7 @@ To mitigate this issue, you can tell Inertia which local component state to cach
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       description: 'Use the "useRememberedState" hook to cache local state.',
       language: 'jsx',
@@ -68,6 +71,7 @@ To mitigate this issue, you can tell Inertia which local component state to cach
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       description: 'Use the "remember" store to cache local state.',
       language: 'js',
@@ -90,8 +94,10 @@ If your page contains multiple components using the remember functionality, you'
 If you have multiple instances of the same component on the page, be sure to include a unique identifier for each of those instances. For example, `Users/Edit:{id}`.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'js',
       code:
@@ -116,6 +122,7 @@ If you have multiple instances of the same component on the page, be sure to inc
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code:
@@ -138,6 +145,7 @@ If you have multiple instances of the same component on the page, be sure to inc
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'js',
       code:

--- a/pages/pages.mdx
+++ b/pages/pages.mdx
@@ -24,8 +24,10 @@ With Inertia, each page in your application has its own controller and correspon
 Pages are simply JavaScript components. There is nothing particularly special about them. Pages receive data from the controllers as props. Here's an example of a simple page component.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -49,6 +51,7 @@ Pages are simply JavaScript components. There is nothing particularly special ab
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code: dedent`
@@ -65,6 +68,7 @@ Pages are simply JavaScript components. There is nothing particularly special ab
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`
@@ -86,8 +90,10 @@ Pages are simply JavaScript components. There is nothing particularly special ab
 While not required, for most projects it makes sense to create a site layout that your pages can extend. Notice in our page example above that we're wrapping the page content within a `<layout>` component. Here's an example of such a component. There is nothing Inertia specific here. This is just a standard JavaScript component.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -121,6 +127,7 @@ While not required, for most projects it makes sense to create a site layout tha
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code: dedent`
@@ -144,6 +151,7 @@ While not required, for most projects it makes sense to create a site layout tha
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`
@@ -176,8 +184,10 @@ While it's simple to implement layouts as children of the page components, it do
 For example, maybe you have an audio player on a podcast website that you want to continue playing as users navigate the site. Or, maybe you simply want to maintain the scroll position in your navigation between page visits. In these situations, using the persistent layouts feature in Inertia is a better choice.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -202,6 +212,7 @@ For example, maybe you have an audio player on a podcast website that you want t
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code: dedent`
@@ -220,6 +231,7 @@ For example, maybe you have an audio player on a podcast website that you want t
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'js',
       code: `// Coming soon`,
@@ -230,8 +242,10 @@ For example, maybe you have an audio player on a podcast website that you want t
 You can also create more complex layout arrangements using nested layouts.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -261,6 +275,7 @@ You can also create more complex layout arrangements using nested layouts.
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code: dedent`
@@ -284,6 +299,7 @@ You can also create more complex layout arrangements using nested layouts.
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'js',
       code: `// Coming soon`,
@@ -306,8 +322,10 @@ When navigating between pages, Inertia will automatically reset the scroll posit
 While it's possible to pass title and meta tag props from pages to layouts (as illustrated above), it's often easier to manage this using a document head library like [Vue Meta](https://github.com/nuxt/vue-meta) or [React Helmet](https://github.com/nfl/react-helmet).
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -337,6 +355,7 @@ While it's possible to pass title and meta tag props from pages to layouts (as i
       description: "Don't forget to install and configure the Vue Meta package.",
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code: dedent`
@@ -358,6 +377,7 @@ While it's possible to pass title and meta tag props from pages to layouts (as i
       description: "Don't forget to install and configure the React Helmet package.",
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'js',
       code: `// Coming soon`,

--- a/pages/redirects.mdx
+++ b/pages/redirects.mdx
@@ -17,8 +17,10 @@ For example, if you're creating a new user, have your "store" endpoint return a 
 Inertia will automatically follow this redirect and update the page accordingly. Here's a simplified example.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       code: dedent`
@@ -44,6 +46,7 @@ Inertia will automatically follow this redirect and update the page accordingly.
       `,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`

--- a/pages/requests.mdx
+++ b/pages/requests.mdx
@@ -21,8 +21,10 @@ export const meta = {
 In addition to [creating links](/links), it's also very common to manually make Inertia visits. The following methods are available. Take note of the defaults.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'js',
       code: dedent`
@@ -83,6 +85,7 @@ In addition to [creating links](/links), it's also very common to manually make 
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'js',
       code: dedent`
@@ -143,6 +146,7 @@ In addition to [creating links](/links), it's also very common to manually make 
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'js',
       code: dedent`

--- a/pages/responses.mdx
+++ b/pages/responses.mdx
@@ -23,8 +23,10 @@ In your controller, provide both the name of the JavaScript page component, as w
 In this example we're passing a single prop, called `event`, which contains four attributes (`id`, `title`, `start_date` and `description`) to the `Event/Show` page component.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       code: dedent`
@@ -47,6 +49,7 @@ In this example we're passing a single prop, called `event`, which contains four
       description: `To make an Inertia response, use the Inertia render function. This method takes the component name, and allows you to pass props and view data.`,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`
@@ -77,8 +80,10 @@ In this example we're passing a single prop, called `event`, which contains four
 When using [partial reloads](/requests#partial-reloads) it's best to wrap the props (data) in a closure, so that it will only be evaluated if it's required.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       code: dedent`
@@ -102,6 +107,7 @@ When using [partial reloads](/requests#partial-reloads) it's best to wrap the pr
       `,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`
@@ -133,8 +139,10 @@ When using [partial reloads](/requests#partial-reloads) it's best to wrap the pr
 There are situations where you may want to access your prop data in your root Blade template. For example, you may want to add a meta description tag, Twitter card meta tags, or Facebook Open Graph meta tags.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'twig',
       code: dedent`
@@ -143,6 +151,7 @@ There are situations where you may want to access your prop data in your root Bl
       description: `These props are available via the $page variable.`,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'erb',
       code: dedent`
@@ -156,8 +165,10 @@ There are situations where you may want to access your prop data in your root Bl
 Sometimes you may even want to provide data that will not be sent to your JavaScript component.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       code: dedent`
@@ -167,6 +178,7 @@ Sometimes you may even want to provide data that will not be sent to your JavaSc
       description: `Do this using the withViewData() method.`,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`
@@ -180,8 +192,10 @@ Sometimes you may even want to provide data that will not be sent to your JavaSc
 You can then access this variable like a regular template variable.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'twig',
       code: dedent`
@@ -189,6 +203,7 @@ You can then access this variable like a regular template variable.
       `,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'erb',
       code: dedent`

--- a/pages/routing.mdx
+++ b/pages/routing.mdx
@@ -5,7 +5,10 @@ import TabbedCodeExamples from '../components/TabbedCodeExamples'
 export default Layout
 export const meta = {
   title: 'Routing',
-  links: [{ url: '#top', name: 'Defining routes' }, { url: '#generating-routes', name: 'Generating URLs' }],
+  links: [
+    { url: '#top', name: 'Defining routes' },
+    { url: '#generating-routes', name: 'Generating URLs' },
+  ],
 }
 
 # Routing
@@ -21,8 +24,10 @@ Some server-side frameworks allow you to generate URLs from named routes. Howeve
 The first option is to generate URLs server-side and include them as props. Notice in this example how we're passing the `edit_url` and `create_url` to the `Users/Index` component.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       code: dedent`
@@ -43,9 +48,10 @@ The first option is to generate URLs server-side and include them as props. Noti
                 ]);
             }
         }
-      `
+      `,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`
@@ -63,7 +69,7 @@ The first option is to generate URLs server-side and include them as props. Noti
             }
           end
         end
-      `
+      `,
     },
   ]}
 />

--- a/pages/security.mdx
+++ b/pages/security.mdx
@@ -25,8 +25,10 @@ Rather, with Inertia you can simply use whatever authentication system your serv
 With Inertia, authorization is best handled server-side in your policies. However, you may be wondering how to check against your policies from within your JavaScript page components, since you won't have access to your server-side helpers. The simplest approach here is to pass your authorization checks as props to your page components.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       code: dedent`
@@ -54,6 +56,7 @@ With Inertia, authorization is best handled server-side in your policies. Howeve
       `,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`

--- a/pages/server-side-setup.mdx
+++ b/pages/server-side-setup.mdx
@@ -20,8 +20,10 @@ export const meta = {
 Install the Inertia server-side adapters using the preferred package manager for that language or framework.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'bash',
       code: dedent`
@@ -30,6 +32,7 @@ Install the Inertia server-side adapters using the preferred package manager for
       description: 'Install via Composer',
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       description: 'Add this to your Gemfile',
@@ -45,8 +48,10 @@ Install the Inertia server-side adapters using the preferred package manager for
 Next, setup the root template that will be loaded on the first page visit. This will be used to load your site assets (CSS and JavaScript), and will also contain a root `<div>` to boot your JavaScript application in.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'twig',
       code: dedent`
@@ -66,6 +71,7 @@ Next, setup the root template that will be loaded on the first page visit. This 
       description: `By default the Laravel adapter will use the app.blade.php view. This template should include your assets, as well as the @inertia directive. If you'd like to use a different root view, you can change it using Inertia::setRootView().`,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`
@@ -83,8 +89,10 @@ Next, setup the root template that will be loaded on the first page visit. This 
 While not required, it's highly recommended that you also configure automatic asset refreshing. To do this you simply need to tell Inertia what the current version of your assets is. See the [asset versioning](/asset-versioning) page for more information.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       code: dedent`
@@ -92,6 +100,7 @@ While not required, it's highly recommended that you also configure automatic as
       `,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`
@@ -108,8 +117,10 @@ While not required, it's highly recommended that you also configure automatic as
 That's it, you're all ready to go server-side! From here you can start creating Inertia responses. See the [responses](/responses) page for more information.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       code: dedent`
@@ -131,6 +142,7 @@ That's it, you're all ready to go server-side! From here you can start creating 
       `,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`

--- a/pages/shared-data.mdx
+++ b/pages/shared-data.mdx
@@ -23,8 +23,10 @@ Sometimes you need to access certain data on numerous pages within your applicat
 The server-side adapters provide a way to preassign shared data for each request. This is typically done outside of your controllers. Shared data will be automatically merged with the page props provided in your controller.
 
 <TabbedCodeExamples
-  examples={[
+ type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       language: 'php',
       code: dedent`
@@ -61,6 +63,7 @@ The server-side adapters provide a way to preassign shared data for each request
       description: 'Place this code in your AppServiceProvider boot method.',
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`
@@ -90,8 +93,10 @@ The server-side adapters provide a way to preassign shared data for each request
 Once you've shared the data server-side, you'll then be able to access it within your page components as props. Shared data can even be accessed in non-page components, although not as props in those cases. Here's an example of how to do this in a layout component.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       description: 'Access shared data using the $page property.',
       language: 'twig',
@@ -115,6 +120,7 @@ Once you've shared the data server-side, you'll then be able to access it within
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       description: 'Access shared data using the usePage() hook.',
       language: 'jsx',
@@ -140,6 +146,7 @@ Once you've shared the data server-side, you'll then be able to access it within
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       description: 'Access shared data using the $page store.',
       language: 'html',
@@ -173,8 +180,10 @@ Another great use-case for shared data is flash messages. These are messages sto
 Here's a simple way to implement flash messages in your Inertia applications. First, share the flash message on each request.
 
 <TabbedCodeExamples
-  examples={[
+  type="backend"
+  snippets={[
     {
+      framework: 'laravel',
       name: 'Laravel',
       description: 'Place this code in your AppServiceProvider boot method.',
       language: 'php',
@@ -189,6 +198,7 @@ Here's a simple way to implement flash messages in your Inertia applications. Fi
       `,
     },
     {
+      framework: 'rails',
       name: 'Rails',
       language: 'ruby',
       code: dedent`
@@ -207,8 +217,10 @@ Here's a simple way to implement flash messages in your Inertia applications. Fi
 Next, display the flash message in a front-end component, such as the site layout.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'twig',
       code: dedent`
@@ -227,6 +239,7 @@ Next, display the flash message in a front-end component, such as the site layou
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code: dedent`
@@ -249,6 +262,7 @@ Next, display the flash message in a front-end component, such as the site layou
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'html',
       code: dedent`

--- a/pages/sponsors.mdx
+++ b/pages/sponsors.mdx
@@ -1,6 +1,5 @@
 import dedent from 'dedent-js'
 import Layout from '../components/Layout'
-import TabbedCodeExamples from '../components/TabbedCodeExamples'
 
 export default Layout
 export const meta = {

--- a/pages/transforming-props.mdx
+++ b/pages/transforming-props.mdx
@@ -10,8 +10,10 @@ export const meta = { title: 'Transforming props' }
 Sometimes it can be useful to transform the props client-side before they are passed to the page component. For example, you may have a collection of errors that you want to convert into a custom `Error` object. You can do this using the `transformProps` callback.
 
 <TabbedCodeExamples
-  examples={[
+  type="frontend"
+  snippets={[
     {
+      framework: 'vue',
       name: 'Vue',
       language: 'js',
       code: dedent`
@@ -33,6 +35,7 @@ Sometimes it can be useful to transform the props client-side before they are pa
       `,
     },
     {
+      framework: 'react',
       name: 'React',
       language: 'jsx',
       code: dedent`
@@ -56,6 +59,7 @@ Sometimes it can be useful to transform the props client-side before they are pa
       `,
     },
     {
+      framework: 'svelte',
       name: 'Svelte',
       language: 'js',
       code: dedent`

--- a/pages/who-is-it-for.mdx
+++ b/pages/who-is-it-for.mdx
@@ -1,7 +1,6 @@
 import dedent from 'dedent-js'
 import Layout from '../components/Layout'
 import Notice from '../components/Notice'
-import TabbedCodeExamples from '../components/TabbedCodeExamples'
 
 export default Layout
 export const meta = {


### PR DESCRIPTION
This pull request adds implementation of localStorage using React Context API to remember the last chosen framework.

- Separate contexts for Backend and Frontend frameworks
- Adds a new prop on TabbedCodeExamples component called `type`. Its value indicate if its a backend or frontend framework example/snippet.

### Problem
On the landing page, `TabbedCodeExamples` component has both `frontend` and `backend` examples at one place 😅 
I did not see that coming. Any thoughts how we can manage that? 

Please leave feedback and help me improve this PR 🙏🏼

Demo:
https://www.loom.com/share/209c7f69222f4462bf196714ef723a64