### PR TITLE
Save code tabs state

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -8,9 +8,41 @@ import TabbedCodeExamples from './TabbedCodeExamples'
 import MarkdownComponents from './MarkdownComponents'
 import React, { useState, useEffect, useRef } from 'react'
 
+export const CodeTabContext = React.createContext()
+
+const getFromLocalStorage = (key, defaultValue = 0) => {
+  if (typeof window === 'undefined') {
+    return defaultValue
+  }
+
+  return parseInt(localStorage.getItem(key) || defaultValue)
+}
+
 export default function Layout({ meta, children }) {
   const mobileNav = useRef(null)
   const [showMobileNav, setShowMobileNav] = useState(false)
+  const initialTabValue = 0;
+  const [codeTabs, setCodeTabsState] = useState({
+    client: initialTabValue,
+    server: initialTabValue,
+  })
+
+  const setCodeTabs = (newValue) => {
+    setCodeTabsState(newValue);
+    localStorage.setItem('currentClientSideTab', newValue.client);
+    localStorage.setItem('currentServerSideTab', newValue.server);
+  };
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    setCodeTabsState({
+      client: getFromLocalStorage('currentClientSideTab'),
+      server: getFromLocalStorage('currentServerSideTab'),
+    })
+  }, [initialTabValue])
 
   useEffect(() => {
     // Algolia DocSearch
@@ -279,7 +311,9 @@ export default function Layout({ meta, children }) {
           className="flex-1 overflow-hidden px-6 md:pl-12 md:pr-0 lg:pl-16 xl:pl-16 xl:pr-20 leading-relaxed text-lg"
           id="top"
         >
-          <MDXProvider components={MarkdownComponents} children={children} />
+          <CodeTabContext.Provider value={[codeTabs, setCodeTabs]}>
+            <MDXProvider components={MarkdownComponents} children={children} />
+          </CodeTabContext.Provider>
         </div>
         <div className="hidden xl:block w-44 flex-shrink-0 relative -mt-8">
           <div className="pt-8 sticky top-0">

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -10,12 +10,18 @@ import React, { useState, useEffect, useRef } from 'react'
 
 export const CodeTabContext = React.createContext()
 
-const getFromLocalStorage = (key, defaultValue = 0) => {
+const getCurrentTabValue = (tabType, defaultValue) => {
   if (typeof window === 'undefined') {
     return defaultValue
   }
 
-  return parseInt(localStorage.getItem(key) || defaultValue)
+  const urlParam = new URLSearchParams(window.location.search).get(tabType)
+
+  if (urlParam) {
+    return urlParam.toLowerCase()
+  }
+
+  return localStorage.getItem(`current${tabType.charAt(0).toUpperCase() + tabType.slice(1)}Tab`) || defaultValue
 }
 
 export default function Layout({ meta, children }) {
@@ -23,14 +29,14 @@ export default function Layout({ meta, children }) {
   const [showMobileNav, setShowMobileNav] = useState(false)
   const initialTabValue = 0;
   const [codeTabs, setCodeTabsState] = useState({
-    client: initialTabValue,
-    server: initialTabValue,
+    frontend: initialTabValue,
+    backend: initialTabValue,
   })
 
-  const setCodeTabs = (newValue) => {
-    setCodeTabsState(newValue);
-    localStorage.setItem('currentClientSideTab', newValue.client);
-    localStorage.setItem('currentServerSideTab', newValue.server);
+  const setCodeTabs = (value) => {
+    setCodeTabsState(value);
+    localStorage.setItem('currentFrontendTab', value.frontend);
+    localStorage.setItem('currentBackendTab', value.backend);
   };
 
   useEffect(() => {
@@ -39,8 +45,8 @@ export default function Layout({ meta, children }) {
     }
 
     setCodeTabsState({
-      client: getFromLocalStorage('currentClientSideTab'),
-      server: getFromLocalStorage('currentServerSideTab'),
+      frontend: getCurrentTabValue('frontend', 'vue.js'),
+      backend: getCurrentTabValue('backend', 'laravel'),
     })
   }, [initialTabValue])
 

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -10,9 +10,9 @@ import React, { useState, useEffect, useRef } from 'react'
 
 export const CodeTabContext = React.createContext()
 
-const getCurrentCodeTab = (tabType) => {
-  const param = new URLSearchParams(location.search).get(tabType);
-  return param ? param.toLowerCase() : localStorage.getItem('tab.' + tabType);
+const getCurrentCodeTab = tabType => {
+  const param = new URLSearchParams(location.search).get(tabType)
+  return param ? param.toLowerCase() : localStorage.getItem('tab.' + tabType)
 }
 
 export default function Layout({ meta, children }) {
@@ -24,16 +24,15 @@ export default function Layout({ meta, children }) {
     backend: 'laravel',
   })
 
-  const setCodeTabs = (value) => {
-    setCodeTabsState(value);
+  const setCodeTabs = value => {
+    setCodeTabsState(value)
 
-    const params = new URLSearchParams(location.search);
-    params.set('frontend', value.frontend);
-    params.set('backend', value.backend);
-    history.replaceState(history.state, '', '?' + params.toString());
+    const params = new URLSearchParams(location.search)
+    params.set('frontend', value.frontend)
+    params.set('backend', value.backend)
 
-    localStorage.setItem('tab.frontend', value.frontend);
-    localStorage.setItem('tab.backend', value.backend);
+    localStorage.setItem('tab.frontend', value.frontend)
+    localStorage.setItem('tab.backend', value.backend)
   }
 
   useEffect(() => {

--- a/components/TabbedCodeExamples.js
+++ b/components/TabbedCodeExamples.js
@@ -1,8 +1,24 @@
 import Code from './Code'
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
+
+import { CodeTabContext } from './Layout'
+
+const guessTabType = (tabNames) => {
+  if (tabNames.includes('laravel')) {
+    return 'server'
+  }
+
+  if (tabNames.includes('vue.js') || tabNames.includes('vue')) {
+    return 'client'
+  }
+
+  return 'unknown'
+}
 
 export default ({ className, examples, height }) => {
-  const [activeTab, setActiveTab] = useState(0)
+  const [codeTabs, setCodeTabs] = useContext(CodeTabContext) || useState({unknown: 0})
+  const tabType = guessTabType(examples.map(example => example.name.toLowerCase()))
+  const activeTab = codeTabs[tabType] ?? 0
 
   return (
     <div className={className}>
@@ -11,7 +27,7 @@ export default ({ className, examples, height }) => {
           <button
             key={index}
             type="button"
-            onClick={() => setActiveTab(index)}
+            onClick={() => setCodeTabs({...codeTabs, [tabType]: index})}
             className="focus:outline-none text-sm text-gray-500 hover:text-gray-200 font-medium px-3 sm:px-6 pt-3 pb-2 rounded-t mr-1"
             css={index === activeTab ? { color: 'white', background: '#202e59' } : {}}
           >

--- a/components/TabbedCodeExamples.js
+++ b/components/TabbedCodeExamples.js
@@ -5,11 +5,11 @@ import { CodeTabContext } from './Layout'
 
 const guessTabType = (tabNames) => {
   if (tabNames.includes('laravel')) {
-    return 'server'
+    return 'backend'
   }
 
   if (tabNames.includes('vue.js') || tabNames.includes('vue')) {
-    return 'client'
+    return 'frontend'
   }
 
   return 'unknown'
@@ -18,7 +18,8 @@ const guessTabType = (tabNames) => {
 export default ({ className, examples, height }) => {
   const [codeTabs, setCodeTabs] = useContext(CodeTabContext) || useState({unknown: 0})
   const tabType = guessTabType(examples.map(example => example.name.toLowerCase()))
-  const activeTab = codeTabs[tabType] ?? 0
+  const exampleIndex = examples.findIndex(example => codeTabs[tabType] === example.name.toLowerCase())
+  const activeTab = exampleIndex < 0 ? 0 : exampleIndex
 
   return (
     <div className={className}>
@@ -27,7 +28,7 @@ export default ({ className, examples, height }) => {
           <button
             key={index}
             type="button"
-            onClick={() => setCodeTabs({...codeTabs, [tabType]: index})}
+            onClick={() => setCodeTabs({...codeTabs, [tabType]: example.name.toLowerCase()})}
             className="focus:outline-none text-sm text-gray-500 hover:text-gray-200 font-medium px-3 sm:px-6 pt-3 pb-2 rounded-t mr-1"
             css={index === activeTab ? { color: 'white', background: '#202e59' } : {}}
           >

--- a/pages/links.mdx
+++ b/pages/links.mdx
@@ -27,7 +27,7 @@ To create an Inertia link, use the Inertia link component. Note, any attributes 
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <inertia-link href="/">Home</inertia-link>
@@ -57,7 +57,7 @@ You can specify the method for an Inertia link request. The default is `GET`, bu
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <inertia-link href="/logout" method="post">Logout</inertia-link>
@@ -87,7 +87,7 @@ You can add data using the `data` attribute. This can be an `object`, or a `Form
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <inertia-link href="/endpoint" method="post" :data="{ foo: bar }">Save</inertia-link>
@@ -117,7 +117,7 @@ You can specify the browser history behaviour. By default page visits push (new)
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <inertia-link href="/" replace>Home</inertia-link>
@@ -147,7 +147,7 @@ You can preserve a page component's local state using the `preserve-state` attri
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <input v-model="query" type="text" />
@@ -180,7 +180,7 @@ By default page visits will automatically reset the scroll position back to the 
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <inertia-link href="/" preserve-scroll>Home</inertia-link>
@@ -210,7 +210,7 @@ The `only` option allows you to request a subset of the props (data) from the se
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <inertia-link href="/" :only="['someProps']">Home</inertia-link>

--- a/pages/local-state-caching.mdx
+++ b/pages/local-state-caching.mdx
@@ -25,7 +25,7 @@ To mitigate this issue, you can tell Inertia which local component state to cach
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       description: 'Use the "remember" property to cache local state.',
       language: 'js',
       code: dedent`
@@ -92,7 +92,7 @@ If you have multiple instances of the same component on the page, be sure to inc
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'js',
       code:
         dedent`

--- a/pages/pages.mdx
+++ b/pages/pages.mdx
@@ -26,7 +26,7 @@ Pages are simply JavaScript components. There is nothing particularly special ab
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <template>
@@ -88,7 +88,7 @@ While not required, for most projects it makes sense to create a site layout tha
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <template>
@@ -178,7 +178,7 @@ For example, maybe you have an audio player on a podcast website that you want t
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <template>
@@ -232,7 +232,7 @@ You can also create more complex layout arrangements using nested layouts.
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <template>
@@ -308,7 +308,7 @@ While it's possible to pass title and meta tag props from pages to layouts (as i
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <template>

--- a/pages/requests.mdx
+++ b/pages/requests.mdx
@@ -23,7 +23,7 @@ In addition to [creating links](/links), it's also very common to manually make 
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'js',
       code: dedent`
         // import { Inertia } from '@inertiajs/inertia'\n

--- a/pages/shared-data.mdx
+++ b/pages/shared-data.mdx
@@ -92,7 +92,7 @@ Once you've shared the data server-side, you'll then be able to access it within
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       description: 'Access shared data using the $page property.',
       language: 'twig',
       code: dedent`
@@ -209,7 +209,7 @@ Next, display the flash message in a front-end component, such as the site layou
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'twig',
       code: dedent`
         <template>

--- a/pages/transforming-props.mdx
+++ b/pages/transforming-props.mdx
@@ -12,7 +12,7 @@ Sometimes it can be useful to transform the props client-side before they are pa
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue',
+      name: 'Vue.js',
       language: 'js',
       code: dedent`
         new Vue({


### PR DESCRIPTION
There are currently two other pull requests open with mostly the same features (#91 and #92). However, we all took some different approaches.

A few key differences that this approach has:
- Uses separate states for frontend/backend frameworks
- No changes required to the templates, since the type of tab (frontend/backend) is guessed
- Uses query parameters instead of the hash, so linking to https://inertiajs.com/client-side-setup?frontend=svelte&backend=laravel#initialize-app works as intended
- A single context provider is used vs multiple or global state (honestly don't know what would be the best approach)

Many thanks to @pxlrbt who helped me review and improve my attempt

Closes #46