### PR TITLE
Fix on shared data documentation page

### DIFF
--- a/pages/shared-data.mdx
+++ b/pages/shared-data.mdx
@@ -176,16 +176,18 @@ Here's a simple way to implement flash messages in your Inertia applications. Fi
   examples={[
     {
       name: 'Laravel',
-      description: 'Place this code in your AppServiceProvider boot method.',
+      description: 'Place this code in your AppServiceProvider register method.',
       language: 'php',
       code: dedent`
-        use Session;
+        use Illuminate\Support\Facades\Session;
         use Inertia\\Inertia;\n
-        Inertia::share('flash', function () {
-            return [
-                'message' => Session::get('message'),
-            ];
-        });
+        Inertia::share([
+            'flash' => function () {
+                return [
+                    'message' => Session::get('message'),
+                ];
+            }
+        ]);
       `,
     },
     {
@@ -204,7 +206,9 @@ Here's a simple way to implement flash messages in your Inertia applications. Fi
   ]}
 />
 
-Next, display the flash message in a front-end component, such as the site layout.
+Any message type (message, success, ...) added to the session in your application will be available in your front end component.
+
+Next, display the flash message in a front-end component, such as the site layout. You can add more message types 
 
 <TabbedCodeExamples
   examples={[


### PR DESCRIPTION
Hello! 

I had the luck to discover this incredible library a while ago and was impressed on how fine it worked! I however stumbled upon a small problem, which was to display errors from Laravel and make them display into my VueJS templates.

When I asked about it, I got redirected to [this page](https://inertiajs.com/shared-data#flash-messages), and found the documentation to be *slightly* incomplete. I got lucky to find out how the PingCRM repository was working to make my own tests, and it worked like a charm almost immediately.

Also, I thought that hinting the reader about how they can pass other things to the Session object than 'message' was quite useful to win some time. For the rest, it's just some syntax fixing and precision.

You all are my new best friends, for sure.

