### PR TITLE
Add section about middleware

### DIFF
--- a/pages/server-side-setup.mdx
+++ b/pages/server-side-setup.mdx
@@ -89,6 +89,33 @@ Next, setup the root template that will be loaded on the first page visit. This 
   ]}
 />
 
+## Middlware
+
+Inertia needs to register a middleware in order to deal with things like version conflicts and redirects. Normally, you won't have to worry about this since Inertia will automatically register the middleware into your framework's middleware stack. If you need more control, you can also manually register the middleware into your middleware stack.
+
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Laravel',
+      language: 'php',
+      code: dedent`
+        use Inertia\\Middleware;\n
+        class Kernel extends HttpKernel
+        {
+            protected $middlewareGroups = [
+                // ...\n
+                'custom-group' => [
+                    Middleware::class,
+                ],
+            ];
+        }
+      `,
+      description:
+        'By default, the Laravel adapter will append the middleware to the "web" middleware group. If you want to change this default, you can modify the intertia.middleware_group configuration setting.',
+    },
+  ]}
+/>
+
 ## Asset versioning
 
 While not required, it's highly recommended that you also configure automatic asset refreshing. To do this you simply need to tell Inertia what the current version of your assets is. See the [asset versioning](/asset-versioning) page for more information.

--- a/pages/server-side-setup.mdx
+++ b/pages/server-side-setup.mdx
@@ -89,7 +89,7 @@ Next, setup the root template that will be loaded on the first page visit. This 
   ]}
 />
 
-## Middlware
+## Middleware
 
 Inertia needs to register a middleware in order to deal with things like version conflicts and redirects. Normally, you won't have to worry about this since Inertia will automatically register the middleware into your framework's middleware stack. If you need more control, you can also manually register the middleware into your middleware stack.
 


### PR DESCRIPTION
This is based on the discussion in this PR https://github.com/inertiajs/inertia-laravel/pull/158

I provided a code example for Laravel on how to register the Inertia middleware into a different middleware group but I'm not sure about what the Rails equivalent would be. From a quick glance at the Rails docs, it doesn't seem like Rails has the concept of different middleware "groups"? Someone with more Rails experience than me (which is 0) please chime in on this part :)

Not super happy with the phrasing about version conflicts and redirects but I essentially wanted to give a very brief explanation about what this middleware is even needed for. I assume most people won't be aware that there even _is_ a middleware (happened to me).

The part about editing the `inertia.middleware_group` config value could also be confusing, because Inertia doesn't publish a config file itself.

I'd appreciate CnC.