### PR TITLE
Use plugin instead of deprecated option

### DIFF
--- a/pages/client-side-setup.mdx
+++ b/pages/client-side-setup.mdx
@@ -61,9 +61,9 @@ Next, update your main JavaScript file to boot your Inertia app. All we're doing
       name: 'Vue.js',
       language: 'js',
       code: dedent`
-        import { InertiaApp } from '@inertiajs/inertia-vue'
+        import { InertiaApp, plugin } from '@inertiajs/inertia-vue'
         import Vue from 'vue'\n
-        Vue.use(InertiaApp)\n
+        Vue.use(plugin)\n
         const app = document.getElementById('app')\n
         new Vue({
           render: h => h(InertiaApp, {

--- a/pages/client-side-setup.mdx
+++ b/pages/client-side-setup.mdx
@@ -181,9 +181,9 @@ Finally, update the `resolveComponent` callback in your app initialization to us
       name: 'Vue.js',
       language: 'js',
       code: dedent`
-        import { InertiaApp } from '@inertiajs/inertia-vue'
+        import { InertiaApp, plugin } from '@inertiajs/inertia-vue'
         import Vue from 'vue'\n
-        Vue.use(InertiaApp)\n
+        Vue.use(plugin)\n
         const app = document.getElementById('app')\n
         new Vue({
           render: h => h(InertiaApp, {


### PR DESCRIPTION
I received a deprecation warning after following the docs, see https://github.com/inertiajs/inertia/commit/1764fd50f46f092e41012bb9846daa07b8a62b15

This PR corrects the docs so that they no longer use the deprecated option of registering the Inertia plugin.