### PR TITLE
Fix how to hide NProgress according to the docs

### DIFF
--- a/pages/events.mdx
+++ b/pages/events.mdx
@@ -219,7 +219,7 @@ The `finish` event fires after an XHR request has completed for both successful 
 import { Inertia } from '@inertiajs/inertia'
 
 Inertia.on('finish', event => {
-  NProgress.stop()
+  NProgress.done()
 })
 ```
 


### PR DESCRIPTION
`NProgress.done()` is how to hide the loading indicator according to basic usage of the package.