### PR TITLE
Add documentation for "as" attribute

### DIFF
--- a/pages/links.mdx
+++ b/pages/links.mdx
@@ -91,6 +91,45 @@ You can specify the method for an Inertia link request. The default is `GET`, bu
   ]}
 />
 
+## As
+
+You can use the `as` attribute to change how an Inertia link is rendered.
+By default Inertia renders link as anchor `<a>` elements.
+However, for non-GET requests it is recommended to use other elements, like `<button>`, to prevent opening non-GET links in a new tab.
+
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Vue.js',
+      language: 'jsx',
+      code: dedent`
+        <inertia-link href="/logout" as="button" method="post" type="button">Logout</inertia-link>\n
+        <!-- Renders: <button type="button">Logout</button> -->
+      `,
+      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
+    },
+    {
+      name: 'React',
+      language: 'jsx',
+      code: dedent`
+        import { InertiaLink } from '@inertiajs/inertia-react'\n
+        <InertiaLink href="/logout" as="button" method="post" type="button">Logout</InertiaLink>\n
+        <!-- Renders: <button type="button">Logout</button> -->
+      `,
+    },
+    {
+      name: 'Svelte',
+      language: 'jsx',
+      code: dedent`
+        import { inertia } from '@inertiajs/inertia-svelte'\n
+        <button use:inertia="{{ href: '/logout', method: 'post' }}" type="button">Logout</button>\n
+        <!-- Renders: <button type="button">Logout</button> -->
+      `,
+      description: 'Svelte does not support dynamic elements yet, but you can use the inertia directive with the same results.'
+    },
+  ]}
+/>
+
 ## Data
 
 You can add data using the `data` attribute. This can be an `object`, or a `FormData` instance.

--- a/pages/links.mdx
+++ b/pages/links.mdx
@@ -1,5 +1,6 @@
 import dedent from 'dedent-js'
 import Layout from '../components/Layout'
+import Notice from '../components/Notice'
 import TabbedCodeExamples from '../components/TabbedCodeExamples'
 
 export default Layout
@@ -20,11 +21,11 @@ export const meta = {
 
 # Links
 
-To create links within an Inertia app you'll need to use the Inertia link component. This is a light wrapper around a standard anchor link that intercepts click events and prevents full page reloads from occurring. This is how Inertia provides a single-page app experience.
+To create links within an Inertia app you'll need to use the Inertia link component. This is a light wrapper around a standard anchor `<a>` link that intercepts click events and prevents full page reloads from occurring. This is how Inertia provides a single-page app experience.
 
 ## Creating links
 
-To create an Inertia link, use the Inertia link component. Note, any attributes you provide will be proxied to the underlying `<a>` tag.
+To create an Inertia link, use the Inertia link component. Note, any attributes you provide will be proxied to the underlying tag.
 
 <TabbedCodeExamples
   examples={[
@@ -57,6 +58,51 @@ To create an Inertia link, use the Inertia link component. Note, any attributes 
   ]}
 />
 
+By default Inertia renders links as anchor `<a>` elements. However, you can change the tag using the `as` attribute.
+
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Vue.js',
+      language: 'jsx',
+      code: dedent`
+        <inertia-link href="/logout" method="post" as="button" type="button">Logout</inertia-link>\n
+        // Renders as:
+        <button type="button">Logout</button>
+      `,
+    },
+    {
+      name: 'React',
+      language: 'jsx',
+      code: dedent`
+        import { InertiaLink } from '@inertiajs/inertia-react'\n
+        <InertiaLink href="/logout" method="post" as="button" type="button">Logout</InertiaLink>\n
+        // Renders as:
+        <button type="button">Logout</button>
+      `,
+    },
+    {
+      name: 'Svelte',
+      language: 'jsx',
+      code: dedent`
+        import { inertia } from '@inertiajs/inertia-svelte'\n
+        <button href="/logout" use:inertia="{{ method: 'post' }}" type="button">Logout</button>\n
+        // Renders as:
+        <button type="button">Logout</button>
+      `,
+      description:
+        'Svelte does not support dynamic elements yet, but you can use the inertia directive to achieve the same results.',
+    },
+  ]}
+/>
+
+<Notice>
+  Creating <inlineCode>POST</inlineCode>/<inlineCode>PUT</inlineCode>/<inlineCode>PATCH</inlineCode>/
+  <inlineCode>DELETE</inlineCode> anchor <inlineCode>&lt;a&gt;</inlineCode> links is discouraged as it causes "Open Link
+  in New Tab/Window" accessibility issues. Instead, consider using a more appropriate element, such as a{' '}
+  <inlineCode>&lt;button&gt;</inlineCode>.
+</Notice>
+
 ## Method
 
 You can specify the method for an Inertia link request. The default is `GET`, but you can also use `POST`, `PUT`, `PATCH`, and `DELETE`.
@@ -87,45 +133,6 @@ You can specify the method for an Inertia link request. The default is `GET`, bu
         <a href="/logout" use:inertia="{{ method: 'post' }}">Logout</a>\n
         <InertiaLink href="/logout" method="post">Logout</InertiaLink>
       `,
-    },
-  ]}
-/>
-
-## As
-
-You can use the `as` attribute to change how an Inertia link is rendered.
-By default Inertia renders link as anchor `<a>` elements.
-However, for non-GET requests it is recommended to use other elements, like `<button>`, to prevent opening non-GET links in a new tab.
-
-<TabbedCodeExamples
-  examples={[
-    {
-      name: 'Vue.js',
-      language: 'jsx',
-      code: dedent`
-        <inertia-link href="/logout" as="button" method="post" type="button">Logout</inertia-link>\n
-        <!-- Renders: <button type="button">Logout</button> -->
-      `,
-      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
-    },
-    {
-      name: 'React',
-      language: 'jsx',
-      code: dedent`
-        import { InertiaLink } from '@inertiajs/inertia-react'\n
-        <InertiaLink href="/logout" as="button" method="post" type="button">Logout</InertiaLink>\n
-        <!-- Renders: <button type="button">Logout</button> -->
-      `,
-    },
-    {
-      name: 'Svelte',
-      language: 'jsx',
-      code: dedent`
-        import { inertia } from '@inertiajs/inertia-svelte'\n
-        <button use:inertia="{{ href: '/logout', method: 'post' }}" type="button">Logout</button>\n
-        <!-- Renders: <button type="button">Logout</button> -->
-      `,
-      description: 'Svelte does not support dynamic elements yet, but you can use the inertia directive with the same results.'
     },
   ]}
 />


### PR DESCRIPTION
This adds documentation for inertiajs/inertia#271

I tried to condense the information in the PR (and related issue) to explain what the `as` attribute does and why it should be used for non-GET requests. I feel like the description is a bit off, but this might be a good start.

For the code examples I added a comment on how the element would be rendered, since it might be a bit confusing to see `as="button" type="button"`, but the type should be included since browsers would otherwise default to submit.