### PR TITLE
Update scroll-management.mdx

### DIFF
--- a/pages/scroll-management.mdx
+++ b/pages/scroll-management.mdx
@@ -62,8 +62,34 @@ This is also possible with [Inertia links](/links) using the `preserve-scroll` a
 
 If your app doesn't use document body scrolling, but instead has scrollable elements (using the `overflow` CSS property), scroll resetting will not work. In these situations you must tell Inertia which scrollable elements to manage by adding a `scroll-region` attribute.
 
-```html
-<div class="overflow-y-auto" scroll-region>
-  <!-- Your page content -->
-</div>
-```
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Vue.js',
+      language: 'jsx',
+      code: dedent`
+        <div class="overflow-y-auto" scroll-region>
+          <!-- Your page content -->
+        </div>
+      `,
+    },
+    {
+      name: 'React',
+      language: 'jsx',
+      code: dedent`
+        <div className="overflow-y-auto" scroll-region="true">
+          {/* Your page content */}
+        </div>
+      `,
+    },
+    {
+      name: 'Svelte',
+      language: 'jsx',
+      code: dedent`
+        <div class="overflow-y-auto" scroll-region>
+          <!-- Your page content -->
+        </div>
+      `,
+    },
+  ]}
+/>


### PR DESCRIPTION
When you add `scroll-region` attribute in React, you will get this warning:

```
Warning: Received `true` for a non-boolean attribute `scroll-region`.
If you want to write it to the DOM, pass a string instead: scroll-region="true" or scroll-region={value.toString()}.
```

I've updated the scroll region section to use tabbed version (mostly for React) to avoid this confusion.

P.S. Adding `scroll-region=""` (with empty string) also removes this warning and adds `scroll-region` to the DOM, but explicitly setting to `true` seemed more _relevant_ and it's still discoverable by [scrollRegions() function](https://github.com/inertiajs/inertia/blob/master/packages/inertia/src/inertia.js#L40).

   