### PR TITLE
Improve Client-side setup instructions fo Vue.js

### DIFF
--- a/pages/client-side-setup.mdx
+++ b/pages/client-side-setup.mdx
@@ -25,13 +25,21 @@ Install the Inertia client-side adapters using NPM or Yarn.
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue.js 2',
       language: 'bash',
       code: dedent`
         npm install @inertiajs/inertia @inertiajs/inertia-vue
         yarn add @inertiajs/inertia @inertiajs/inertia-vue
       `,
     },
+    {
+          name: 'Vue.js 3',
+          language: 'bash',
+          code: dedent`
+            npm install @inertiajs/inertia @inertiajs/inertia-vue3
+            yarn add @inertiajs/inertia @inertiajs/inertia-vue3
+          `,
+        },
     {
       name: 'React',
       language: 'bash',
@@ -58,28 +66,9 @@ Next, update your main JavaScript file to boot your Inertia app. All we're doing
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue.js 2',
       language: 'js',
       code: dedent`
-        /*
-        |----------------------------------------------------------------
-        | Vue 3
-        |----------------------------------------------------------------
-        */\n
-        import { createApp, h } from 'vue'
-        import { App, plugin } from '@inertiajs/inertia-vue3'\n
-        const el = document.getElementById('app')\n
-        createApp({
-          render: () => h(App, {
-            initialPage: JSON.parse(el.dataset.page),
-            resolveComponent: name => require(\`./Pages/\${name}\`).default,
-          })
-        }).use(plugin).mount(el)\n\n
-        /*
-        |----------------------------------------------------------------
-        | Vue 2
-        |----------------------------------------------------------------
-        */\n
         import { App, plugin } from '@inertiajs/inertia-vue'
         import Vue from 'vue'\n
         Vue.use(plugin)\n
@@ -92,6 +81,21 @@ Next, update your main JavaScript file to boot your Inertia app. All we're doing
             },
           }),
         }).$mount(el)
+      `,
+    },
+    {
+      name: 'Vue.js 3',
+      language: 'js',
+      code: dedent`
+        import { createApp, h } from 'vue'
+        import { App, plugin } from '@inertiajs/inertia-vue3'\n
+        const el = document.getElementById('app')\n
+        createApp({
+          render: () => h(App, {
+            initialPage: JSON.parse(el.dataset.page),
+            resolveComponent: name => require(\`./Pages/\${name}\`).default,
+          })
+        }).use(plugin).mount(el)\n\n
       `,
     },
     {

--- a/pages/client-side-setup.mdx
+++ b/pages/client-side-setup.mdx
@@ -95,7 +95,7 @@ Next, update your main JavaScript file to boot your Inertia app. All we're doing
             initialPage: JSON.parse(el.dataset.page),
             resolveComponent: name => require(\`./Pages/\${name}\`).default,
           })
-        }).use(plugin).mount(el)\n\n
+        }).use(plugin).mount(el)
       `,
     },
     {


### PR DESCRIPTION
Good evening,

This PR aims to improve the instructions for the Vue.js client-side setup.

1. It adds the missing Vue 3 specific instructions to the **Install dependencies** section.
2. It splits Vue.js versions and puts them in their own tabs.

Let me know what you think :)