### PR TITLE
Add Rails CSRF protection example

### DIFF
--- a/pages/csrf-protection.mdx
+++ b/pages/csrf-protection.mdx
@@ -84,7 +84,11 @@ But, this isn't a great user experience. A better way to handle these errors is 
       name: 'Rails',
       language: 'ruby',
       code: dedent`
-        # todo
+        class ApplicationController < ActionController::Base
+          rescue_from ActionController::InvalidAuthenticityToken do
+            redirect_back fallback_location: '/', notice: 'The page expired, please try again.'
+          end
+        end
       `,
     },
   ]}


### PR DESCRIPTION
I added an example code for Rails to handle InvalidAuthenticityToken exception. It redirects back to the previous page, along with a flash message that the page expired.

I thought about adding a comment about `fallback_location`. It's a required argument, and without it, the method will throw an error. The provided location is used in the case when HTTP_REFERER is not present. In the end, I thought that it's quite self-explanatory. Feel free to add the comment though if you decide it's needed.