### PR TITLE
Remove `url()` from ziggy route() method

### DIFF
--- a/pages/routing.mdx
+++ b/pages/routing.mdx
@@ -79,7 +79,7 @@ Another option is to make your route definitions available client-side as JSON, 
 If you're using Laravel, the <a href="https://github.com/tightenco/ziggy">Ziggy</a> library does this for you automatically via a global `route()` function. If you're using Ziggy with Vue.js, it's helpful to make this function available as a custom `$route` property so you can use it directly in your templates.
 
 ```js
-Vue.prototype.$route = (...args) => route(...args).url()
+Vue.prototype.$route = route
 ```
 
 ```html


### PR DESCRIPTION
The `url()` method was removed in v1 see https://github.com/tighten/ziggy/blob/main/UPGRADING.md#user-content-url-removed