### PR TITLE
Fixes nprogress installation command

### DIFF
--- a/pages/progress-indicators.mdx
+++ b/pages/progress-indicators.mdx
@@ -58,8 +58,8 @@ It's also possible to setup your own custom page loading indicators, using Inert
 First, install the NProgress library.
 
 ```bash
-npm install @nprogress
-yarn add @nprogress
+npm install nprogress
+yarn add nprogress
 ```
 
 You'll need to add the NProgress [styles](https://github.com/rstacruz/nprogress/blob/master/nprogress.css) to your project. You can do this using the CDN version.


### PR DESCRIPTION
[Nprogress](https://github.com/rstacruz/nprogress) needs to be installed without `@` 