### PR TITLE
Update docs for some new inertia-rails features

### DIFF
--- a/pages/partial-reloads.mdx
+++ b/pages/partial-reloads.mdx
@@ -115,7 +115,11 @@ When Inertia performs a visit, it will determine which data is required, and onl
               # ALWAYS included on first visit
               # OPTIONALLY included on partial reloads
               # ONLY evaluated when needed
-              users: -> { User.as_json() },
+              users: -> { User.as_json() },\n
+              # NEVER included on first visit
+              # OPTIONALLY included on partial reloads
+              # ONLY evaluated when needed
+              users: InertiaRails.lazy(-> { User.as_json }),
             }
           end
         end

--- a/pages/redirects.mdx
+++ b/pages/redirects.mdx
@@ -88,7 +88,7 @@ Sometimes it's necessary to redirect to an external website, or even another non
       name: 'Rails',
       language: 'ruby',
       code: dedent`
-        # todo
+        inertia_location index_path
       `,
     },
   ]}

--- a/pages/routing.mdx
+++ b/pages/routing.mdx
@@ -14,6 +14,29 @@ export const meta = {
 
 With Inertia all routing is defined server-side. Meaning you don't need Vue Router or React Router. Simply create routes using your server-side framework of choice.
 
+## Route Helpers
+
+If you have a page that doesn't need a corresponding controller method, like an FAQ or About page, you can route directly to a component.
+
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Laravel',
+      language: 'php',
+      code: dedent`
+        Route::inertia('/about', 'AboutComponent');
+      `,
+    },
+    {
+      name: 'Rails',
+      language: 'ruby',
+      code: dedent`
+        inertia 'about' => 'AboutComponent'
+      `,
+    }
+  ]}
+/>
+
 ## Generating URLs
 
 Some server-side frameworks allow you to generate URLs from named routes. However, you will not have access to those helpers client-side. Here are a couple ways to still use named routes with Inertia.


### PR DESCRIPTION
This PR adds documentation for recent Inertia-Rails features that Inertia-Laravel was already enjoying. It also includes a new section to document both framework's route helpers (pending PR in inertia-rails).

Includes examples for:

External Redirects: https://github.com/inertiajs/inertia-rails/pull/48
Lazy Props: https://github.com/inertiajs/inertia-rails/pull/52
Route Helpers: https://github.com/inertiajs/inertia-rails/pull/54 ~~\*pending merge~~


resolves https://github.com/inertiajs/inertia-rails/issues/49