### PR TITLE
Remove Inertia Lazy hinting for Rails

### DIFF
--- a/pages/partial-reloads.mdx
+++ b/pages/partial-reloads.mdx
@@ -128,4 +128,3 @@ When Inertia performs a visit, it will determine which data is required, and onl
   ]}
 />
 
-Notice how in the Laravel adapter you can use `Inertia::lazy()` to even prevent the prop from being included on the initial page visit. We [hope to bring](https://github.com/inertiajs/inertia-rails/issues/51) this feature to the Rails adapter soon.


### PR DESCRIPTION
Now that `InertiaRails.lazy` has been added to Rails adapter https://github.com/inertiajs/inertia-rails/pull/52 we don't need this paragraph anymore.