### PR TITLE
Create new validation page

### DIFF
--- a/components/Nav.js
+++ b/components/Nav.js
@@ -127,6 +127,11 @@ const Nav = ({ className }) => {
           </Link>
         </li>
         <li className="md:pr-3">
+          <Link href="/validation">
+            <a className={linkClass('/validation')}>Validation</a>
+          </Link>
+        </li>
+        <li className="md:pr-3">
           <Link href="/shared-data">
             <a className={linkClass('/shared-data')}>Shared data</a>
           </Link>

--- a/pages/forms.mdx
+++ b/pages/forms.mdx
@@ -193,7 +193,7 @@ You can learn more about the `FormData` interface [here](https://developer.mozil
 
 ## Form helper
 
-Included in `inertia-vue@v0.5.0` and `inertia-vue3@v0.3.0` is a new form helper, which helps reduce the boilerplate required for a typical form. Here's how to use it:
+Since working with forms is so common, Inertia comes with a form helper designed to help reduce the amount of boilerplate needed for typical forms. Here's how to use it:
 
 <TabbedCodeExamples
   examples={[
@@ -268,21 +268,7 @@ Included in `inertia-vue@v0.5.0` and `inertia-vue3@v0.3.0` is a new form helper,
   ]}
 />
 
-Form errors are available via `form.errors`, and can be cleared by calling `form.clearErrors()`. To clear the errors for a specific field, call `form.clearErrors('field', 'anotherfield')`, passing in the field name(s).
-
-To reset the form back to its original state, use the `form.reset()` method. Or, if you want to only reset specific fields, you can call `form.reset('field', 'anotherfield')`. Resetting the form, or specific fields, also automatically clears the errors.
-
-Use the `form.processing` property to track if a form is currently being submitted. This can be helpful for preventing double form submissions, by disabling the submit button.
-
-In the event that you're uploading files, the current progress event is available via the `form.progress` property. This is helpful for showing upload progress. For example:
-
-```jsx
-<progress :value="form.progress.percentage" max="100">
-  {{ form.progress.percentage }}%
-</progress>
-```
-
-Finally, if you need to modify the form data before it's sent to the server, you can do this via the `transform()` method.
+If you need to modify the form data before it's sent to the server, you can do this via the `transform()` method.
 
 ```js
 this.form
@@ -291,6 +277,48 @@ this.form
     remember: data.remember ? 'on' : '',
   }))
   .post('/login')
+```
+
+You can use the `form.processing` property to track if a form is currently being submitted. This can be helpful for preventing double form submissions, by disabling the submit button.
+
+```jsx
+<button type="submit" :disabled="form.processing">Submit</button>
+```
+
+In the event that you're uploading files, the current progress event is available via the `form.progress` property. This is helpful for showing upload progress. For example:
+
+```jsx
+<progress v-if="form.progress" :value="form.progress.percentage" max="100">
+  {{ form.progress.percentage }}%
+</progress>
+```
+
+In the event there are form errors, they are available via the `form.errors` property.
+
+```jsx
+<div v-if="form.errors.email">{{ form.errors.email }}</div>
+```
+
+To check if a form has any errors, use the `form.hasErrors` property. To clear form errors, use `form.clearErrors()` method.
+
+```js
+// Clear all errors
+form.clearErrors()
+
+// Clear errors for specific fields
+form.clearErrors('field', 'anotherfield')
+```
+
+When a form has been successfully submitted, the `form.wasSuccessful` property will be `true`. In addition to this, there is also a `form.recentlySuccessful` property, which will be set to `true` for two seconds after a successful form submission. This is helpful for showing temporary success messages.
+
+To reset the form values back to their original values, use the `form.reset()` method. Note, this will reset the values back to the initial values that were provided when you called `Inertia.form()`.
+
+```js
+// Reset the form
+form.reset()
+
+// Reset specific fields
+form.reset('field', 'anotherfield')
 ```
 
 ## Server-side validation

--- a/pages/forms.mdx
+++ b/pages/forms.mdx
@@ -7,9 +7,9 @@ export const meta = {
   title: 'Forms',
   links: [
     { url: '#submitting-forms', name: 'Submitting forms' },
-    { url: '#server-side-validation', name: 'Server-side validation' },
     { url: '#file-uploads', name: 'File uploads' },
     { url: '#form-helper', name: 'Form helper' },
+    { url: '#server-side-validation', name: 'Server-side validation' },
     { url: '#classic-xhr-submits', name: 'Classic XHR submits' },
   ],
 }
@@ -172,166 +172,6 @@ Unlike a classic ajax submitted form, with Inertia you don't handle the post sub
   ]}
 />
 
-## Server-side validation
-
-Handling server-side validation errors (`422` responses) in Inertia works a little different than a classic ajax-driven form, where you catch the validation errors in the response and then update the form state. The trick is to handle the validation errors more like a server-side framework.
-
-First, you submit your form using Inertia. If there are validation errors, you redirect server-side back to your form page, including the errors in the session. Your server-side framework likely already does this automatically.
-
-From there you need to send those error messages to your form page component. You can do this in your controller, but it's better to simply do this automatically for all your page components. You can use the Inertia [share](/shared-data) functionality to accomplish this.
-
-Some adapters, such as the Laravel adapter (as of [v0.2.9](https://github.com/inertiajs/inertia-laravel/releases/tag/v0.2.9)), do this automatically, making the validation errors available via the `errors` prop. However, if you'd like to share them manually (maybe you'd like the errors in a different format), you can still do this:
-
-<TabbedCodeExamples
-  examples={[
-    {
-      name: 'Laravel',
-      language: 'php',
-      code: dedent`
-        class HandleInertiaRequests extends Middleware
-        {
-            public function share(Request $request)
-            {
-                return array_merge(parent::share($request), [
-                    'errors' => fn () => $request->session()->get('errors')
-                        ? $request->session()->get('errors')->getBag('default')->getMessages()
-                        : (object) []
-                ]);
-            }
-        }
-      `,
-    },
-    {
-      name: 'Rails',
-      language: 'ruby',
-      code: dedent`
-        # todo
-      `,
-    },
-  ]}
-/>
-
-Now the validation errors will be available as part of your page props, and since they are reactive your template will automatically display them. Here's an updated version of the form example above that displays server-side validation errors.
-
-<TabbedCodeExamples
-  examples={[
-    {
-      name: 'Vue.js',
-      language: 'twig',
-      code: dedent`
-        <template>
-          <form @submit.prevent="submit">
-            <label for="first_name">First name:</label>
-            <input id="first_name" v-model="form.first_name" />
-            <div v-if="errors.first_name">{{ errors.first_name[0] }}</div>
-            <label for="last_name">Last name:</label>
-            <input id="last_name" v-model="form.last_name" />
-            <div v-if="errors.last_name">{{ errors.last_name[0] }}</div>
-            <label for="email">Email:</label>
-            <input id="email" v-model="form.email" />
-            <div v-if="errors.email">{{ errors.email[0] }}</div>
-            <button type="submit">Submit</button>
-          </form>
-        </template>\n
-        <script>
-        export default {
-          props: {
-            errors: Object,
-          },
-          data() {
-            return {
-              form: {
-                first_name: null,
-                last_name: null,
-                email: null,
-              },
-            }
-          },
-          methods: {
-            submit() {
-              this.$inertia.post('/users', this.form)
-            },
-          },
-        }
-        </script>
-      `,
-    },
-    {
-      name: 'React',
-      language: 'jsx',
-      code: dedent`
-        import { Inertia } from '@inertiajs/inertia'
-        import { usePage } from '@inertiajs/inertia-react'
-        import React, { useState } from 'react'\n
-        export default function Edit() {
-          const { errors } = usePage().props\n
-          const [values, setValues] = useState({
-            first_name: null,
-            last_name: null,
-            email: null,
-          })\n
-          function handleChange(e) {
-            setValues(values => ({
-              ...values,
-              [e.target.id]: e.target.value,
-            }))
-          }\n
-          function handleSubmit(e) {
-            e.preventDefault()
-            Inertia.post('/users', values)
-          }\n
-          return (
-            <form onSubmit={handleSubmit}>
-              <label for="first_name">First name:</label>
-              <input id="first_name" value={values.first_name} onChange={handleChange} />
-              {errors.first_name && <div>{errors.first_name[0]}</div>}
-              <label for="last_name">Last name:</label>
-              <input id="last_name" value={values.last_name} onChange={handleChange} />
-              {errors.last_name && <div>{errors.last_name[0]}</div>}
-              <label for="email">Email:</label>
-              <input id="email" value={values.email} onChange={handleChange} />
-              {errors.email && <div>{errors.email[0]}</div>}
-              <button type="submit">Submit</button>
-            </form>
-          )
-        }
-      `,
-    },
-    {
-      name: 'Svelte',
-      language: 'html',
-      code: dedent`
-        <script>
-          import { Inertia } from '@inertiajs/inertia'\n
-          export let errors = {}\n
-          let values = {
-            first_name: null,
-            last_name: null,
-            email: null,
-          }\n
-          function handleSubmit() {
-            Inertia.post('/users', values)
-          }
-        </script>\n
-        <form on:submit|preventDefault={handleSubmit}>
-          <label for="first_name">First name:</label>
-          <input id="first_name" bind:value={values.first_name}>
-          {#if errors.first_name}<div>{errors.first_name}</div>{/if}\n
-          <label for="last_name">Last name:</label>
-          <input id="last_name" bind:value={values.last_name}>
-          {#if errors.last_name}<div>{errors.last_name}</div>{/if}\n
-          <label for="email">Email:</label>
-          <input id="email" bind:value={values.email}>
-          {#if errors.email}<div>{errors.email}</div>{/if}\n
-          <button type="submit">Submit</button>
-        </form>
-      `,
-    },
-  ]}
-/>
-
-While this is very similar to how you would normally do classic server-side form submissions, this approach is much nicer, since you're not reloading the whole page and rehydrating form input data.
-
 ## File uploads
 
 The trick to uploading files with Inertia is using the `FormData` object, since that's what's required to submit a `multipart/form-data` request via XHR. Here is a simple example of using `FormData` with Inertia.
@@ -446,12 +286,16 @@ Finally, if you need to modify the form data before it's sent to the server, you
 
 ```js
 this.form
-  .transform(data => ({
+  .transform((data) => ({
     ...data,
     remember: data.remember ? 'on' : '',
   }))
   .post('/login')
 ```
+
+## Server-side validation
+
+Handling server-side validation errors in Inertia works a little different than a classic ajax-driven form, where you catch the validation errors from `422` responses and manually update the form's error state. That's because Inertia never receives `422` responses. Rather, Inertia operates much more like a standard full page form submission. See the [validation page](/validation) for more information.
 
 ## Classic XHR submits
 

--- a/pages/manual-visits.mdx
+++ b/pages/manual-visits.mdx
@@ -13,6 +13,7 @@ export const meta = {
     { url: '#component-state', name: 'Component state' },
     { url: '#scroll-preservation', name: 'Scroll preservation' },
     { url: '#partial-reloads', name: 'Partial reloads' },
+    { url: '#error-bags', name: 'Error bags' },
     { url: '#custom-headers', name: 'Custom headers' },
     { url: '#visit-cancellation', name: 'Visit cancellation' },
     { url: '#event-callbacks', name: 'Event callbacks' },
@@ -39,6 +40,7 @@ In addition to [creating links](/links), it's also possible to manually make Ine
           preserveScroll: false,
           only: [],
           headers: {},
+          errorBag = null,
           onCancelToken: cancelToken => {},
           onCancel: () => {},
           onBefore: visit => {},
@@ -63,6 +65,7 @@ In addition to [creating links](/links), it's also possible to manually make Ine
           preserveScroll: false,
           only: [],
           headers: {},
+          errorBag = null,
           onCancelToken: cancelToken => {},
           onCancel: () => {},
           onBefore: visit => {},
@@ -87,6 +90,7 @@ In addition to [creating links](/links), it's also possible to manually make Ine
           preserveScroll: false,
           only: [],
           headers: {},
+          errorBag = null,
           onCancelToken: cancelToken => {},
           onCancel: () => {},
           onBefore: visit => {},
@@ -228,6 +232,18 @@ Inertia.visit('/users', { search: 'John' }, { only: ['users'] })
 ```
 
 For more information, see the [partial reloads](/partial-reloads) page.
+
+## Error bags
+
+For pages that have more than one form, it's possible to run into conflicts when displaying validation errors if two forms share the same field names. To get around this, you can use error bags. Error bags scope the validation errors returned from the server within a unique key specific to that form.
+
+```js
+Inertia.post('/companies', data, {
+  errorBag: 'createCompany',
+})
+```
+
+For more information, see the [validation](/validation#error-bags) page.
 
 ## Custom headers
 

--- a/pages/validation.mdx
+++ b/pages/validation.mdx
@@ -1,0 +1,322 @@
+import dedent from 'dedent-js'
+import Layout from '../components/Layout'
+import TabbedCodeExamples from '../components/TabbedCodeExamples'
+
+export default Layout
+export const meta = {
+  title: 'Validation',
+  links: [
+    {
+      url: '#how-it-works',
+      name: 'How it works',
+    },
+    {
+      url: '#sharing-errors',
+      name: 'Sharing errors',
+    },
+    {
+      url: '#displaying-errors',
+      name: 'Displaying errors',
+    },
+    {
+      url: '#repopulating-input',
+      name: 'Repopulating input',
+    },
+    {
+      url: '#resolving-errors',
+      name: 'Resolving errors',
+    },
+    {
+      url: '#error-bags',
+      name: 'Error bags',
+    },
+  ],
+}
+
+# Validation
+
+## How it works
+
+Handling server-side validation errors in Inertia works a little different than a classic ajax-driven form, where you catch the validation errors from `422` responses and manually update the form's error state. That's because Inertia never receives `422` responses. Rather, Inertia operates much more like a standard full page form submission. Here's how:
+
+First, you submit your form using Inertia. In the event that there are server-side validation errors, you don't immediately return those errors as a `422` JSON response. Instead, you redirect (server-side) back to the form page you are on, flashing the validation errors in the session. Frameworks like Laravel do this automatically.
+
+Next, any time these validation errors are present in the session, they automatically get shared with Inertia, making them available client-side as page props, which you can display in your form. Since props are reactive, they are automatically shown when the form submission completes.
+
+## Sharing errors
+
+In order for your server-side validation errors to be available client-side, your server-side framework must share them via the `errors` prop. Some adapters, such as the Laravel adapter, do this automatically. For others, you may need to do this manually. Please refer to your specific server-side adapter documentation for more information.
+
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Laravel',
+      language: 'php',
+      code: dedent`
+        class UsersController extends Controller
+        {
+            public function create()
+            {
+                return Inertia::render('Users/Create');
+            }\n
+            public function store()
+            {
+              Request::validate([
+                  'first_name' => ['required', 'max:50'],
+                  'last_name' => ['required', 'max:50'],
+                  'email' => ['required', 'max:50', 'email'],
+              ]);\n
+              $user = User::create(
+                Request::only('first_name', 'last_name', 'email')
+              );\n
+              return Redirect::route('users.show', $user);
+            }
+        }
+      `,
+    },
+    {
+      name: 'Rails',
+      language: 'ruby',
+      code: dedent`
+        # todo
+      `,
+    },
+  ]}
+/>
+
+## Displaying errors
+
+Since validation errors are made available client-side as page component props, you can conditionally display them based on their existence. Here's an example how.
+
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Vue.js',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <form @submit.prevent="submit">
+            <label for="first_name">First name:</label>
+            <input id="first_name" v-model="form.first_name" />
+            <div v-if="errors.first_name">{{ errors.first_name }}</div>
+            <label for="last_name">Last name:</label>
+            <input id="last_name" v-model="form.last_name" />
+            <div v-if="errors.last_name">{{ errors.last_name }}</div>
+            <label for="email">Email:</label>
+            <input id="email" v-model="form.email" />
+            <div v-if="errors.email">{{ errors.email }}</div>
+            <button type="submit">Submit</button>
+          </form>
+        </template>\n
+        <script>
+        export default {
+          props: {
+            errors: Object,
+          },
+          data() {
+            return {
+              form: {
+                first_name: null,
+                last_name: null,
+                email: null,
+              },
+            }
+          },
+          methods: {
+            submit() {
+              this.$inertia.post('/users', this.form)
+            },
+          },
+        }
+        </script>
+      `,
+    },
+    {
+      name: 'React',
+      language: 'jsx',
+      code: dedent`
+        import { Inertia } from '@inertiajs/inertia'
+        import { usePage } from '@inertiajs/inertia-react'
+        import React, { useState } from 'react'\n
+        export default function Edit() {
+          const { errors } = usePage().props\n
+          const [values, setValues] = useState({
+            first_name: null,
+            last_name: null,
+            email: null,
+          })\n
+          function handleChange(e) {
+            setValues(values => ({
+              ...values,
+              [e.target.id]: e.target.value,
+            }))
+          }\n
+          function handleSubmit(e) {
+            e.preventDefault()
+            Inertia.post('/users', values)
+          }\n
+          return (
+            <form onSubmit={handleSubmit}>
+              <label for="first_name">First name:</label>
+              <input id="first_name" value={values.first_name} onChange={handleChange} />
+              {errors.first_name && <div>{errors.first_name}</div>}
+              <label for="last_name">Last name:</label>
+              <input id="last_name" value={values.last_name} onChange={handleChange} />
+              {errors.last_name && <div>{errors.last_name}</div>}
+              <label for="email">Email:</label>
+              <input id="email" value={values.email} onChange={handleChange} />
+              {errors.email && <div>{errors.email}</div>}
+              <button type="submit">Submit</button>
+            </form>
+          )
+        }
+      `,
+    },
+    {
+      name: 'Svelte',
+      language: 'html',
+      code: dedent`
+        <script>
+          import { Inertia } from '@inertiajs/inertia'\n
+          export let errors = {}\n
+          let values = {
+            first_name: null,
+            last_name: null,
+            email: null,
+          }\n
+          function handleSubmit() {
+            Inertia.post('/users', values)
+          }
+        </script>\n
+        <form on:submit|preventDefault={handleSubmit}>
+          <label for="first_name">First name:</label>
+          <input id="first_name" bind:value={values.first_name}>
+          {#if errors.first_name}<div>{errors.first_name}</div>{/if}\n
+          <label for="last_name">Last name:</label>
+          <input id="last_name" bind:value={values.last_name}>
+          {#if errors.last_name}<div>{errors.last_name}</div>{/if}\n
+          <label for="email">Email:</label>
+          <input id="email" bind:value={values.email}>
+          {#if errors.email}<div>{errors.email}</div>{/if}\n
+          <button type="submit">Submit</button>
+        </form>
+      `,
+    },
+  ]}
+/>
+
+Note, in the Vue adapters, you can also access the errors via the `$page.props.error` object.
+
+## Repopulating input
+
+While handling errors in Inertia is similar to full page form submissions, this approach is actually much nicer, since you don't need to manually repopulate old form input data.
+
+When validation errors occur, the user is automatically redirected back to the form page they are already on. And, by default, Inertia automatically preserves the [component state](/manual-visits#component-state) for `post`, `put`, `patch`, and `delete` requests. Meaning, all the old form input data remains exactly as it is.
+
+The only thing that changes is the `errors` prop, which now contains the validation errors.
+
+## Resolving errors
+
+Since Inertia apps never generate `422` responses, Inertia needs another way to determine if a response includes validation errors. To do this, Inertia checks the `page.props.errors` object for the existence of any errors. In the event that errors are present, the `onError()` callback will be called instead of the `onSuccess()` callback.
+
+If you're applications shares errors using a different prop than `errors`, you must tell Inertia how to resolve these errors. This can be done using the `resolveErrors()` callback, applied at the adapter level.
+
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Vue.js',
+      language: 'js',
+      code: dedent`
+        /*
+        |----------------------------------------------------------------
+        | Vue 3
+        |----------------------------------------------------------------
+        */\n
+        import { createApp, h } from 'vue'
+        import { App, plugin } from '@inertiajs/inertia-vue3'\n
+        const el = document.getElementById('app')\n
+        createApp({
+          render: () => h(App, {
+            initialPage: JSON.parse(el.dataset.page),
+            resolveComponent: name => require(\`./Pages/\${name}\`).default,
+            resolveErrors: page => (page.props.errors || {}),
+          })
+        }).use(plugin).mount(el)\n\n
+        /*
+        |----------------------------------------------------------------
+        | Vue 2
+        |----------------------------------------------------------------
+        */\n
+        import { App, plugin } from '@inertiajs/inertia-vue'
+        import Vue from 'vue'\n
+        Vue.use(plugin)\n
+        const el = document.getElementById('app')\n
+        new Vue({
+          render: h => h(App, {
+            props: {
+              initialPage: JSON.parse(el.dataset.page),
+              resolveComponent: name => require(\`./Pages/\${name}\`).default,
+              resolveErrors: page => (page.props.errors || {}),
+            },
+          }),
+        }).$mount(el)
+      `,
+    },
+    {
+      name: 'React',
+      language: 'jsx',
+      code: dedent`
+        import { App } from '@inertiajs/inertia-react'
+        import React from 'react'
+        import { render } from 'react-dom'\n
+        const el = document.getElementById('app')\n
+        render(
+          <App
+            initialPage={JSON.parse(el.dataset.page)}
+            resolveComponent={name => require(\`./Pages/\${name}\`).default}
+            resolveErrors={page => (page.props.errors || {})},
+          />,
+          el
+        )
+      `,
+    },
+    {
+      name: 'Svelte',
+      language: 'js',
+      code: dedent`
+        import { App } from '@inertiajs/inertia-svelte'\n
+        const el = document.getElementById('app')\n
+        new App({
+          target: el,
+          props: {
+            initialPage: JSON.parse(el.dataset.page),
+            resolveComponent: name => require(\`./Pages/\${name}.svelte\`),
+            resolveErrors: page => (page.props.errors || {}),
+          },
+        })
+      `,
+    },
+  ]}
+/>
+
+Note, the `resolveErrors()` callback must return an object.
+
+## Error bags
+
+For pages that have more than one form, you can run into conflicts when displaying validation errors if two forms share the same field names. For example, imagine a "create company" form and a "create user" form that both have a `name` field. Since both forms will be displaying the `page.props.errors.name` validation error, generating a validation error for the `name` field in either form will cause the error to appear in both forms.
+
+To get around this, you can use error bags. Error bags scope the validation errors returned from the server within a unique key specific to that form. Continuing with our example above, you might have a `createCompany` error bag for the first form, and a `createUser` error bag for the second form.
+
+```js
+Inertia.post('/companies', data, {
+  errorBag: 'createCompany',
+})
+
+Inertia.post('/users', data, {
+  errorBag: 'createUser',
+})
+```
+
+Doing this will cause the validation errors to come back from the server as `page.props.errors.createCompany` and `page.props.errors.createUser`.
+
+Note, if you're using the [form helper](/forms#form-helper), it's not necessary to use error bags, since validation errors are automatically scoped to the form object.

--- a/pages/validation.mdx
+++ b/pages/validation.mdx
@@ -303,7 +303,7 @@ Note, the `resolveErrors()` callback must return an object.
 
 ## Error bags
 
-For pages that have more than one form, you can run into conflicts when displaying validation errors if two forms share the same field names. For example, imagine a "create company" form and a "create user" form that both have a `name` field. Since both forms will be displaying the `page.props.errors.name` validation error, generating a validation error for the `name` field in either form will cause the error to appear in both forms.
+For pages that have more than one form, it's possible to run into conflicts when displaying validation errors if two forms share the same field names. For example, imagine a "create company" form and a "create user" form that both have a `name` field. Since both forms will be displaying the `page.props.errors.name` validation error, generating a validation error for the `name` field in either form will cause the error to appear in both forms.
 
 To get around this, you can use error bags. Error bags scope the validation errors returned from the server within a unique key specific to that form. Continuing with our example above, you might have a `createCompany` error bag for the first form, and a `createUser` error bag for the second form.
 


### PR DESCRIPTION
This PR adds a new page to the docs entirely focused on validation errors. I did this since, as of recent versions of Inertia, validation errors have become a first class feature. I took the existing server-side validation content from the forms page, and expanded on it.

Also includes some changes to other pages, because I was too lazy to switch branches. 😂 