### PR TITLE
Fix Ziggy global function

### DIFF
--- a/pages/routing.mdx
+++ b/pages/routing.mdx
@@ -106,7 +106,7 @@ Another option is to make your route definitions available client-side as JSON, 
 If you're using Laravel, the <a href="https://github.com/tightenco/ziggy">Ziggy</a> library does this for you automatically via a global `route()` function. If you're using Ziggy with Vue.js, it's helpful to make this function available as a custom `$route` property so you can use it directly in your templates.
 
 ```js
-Vue.prototype.$route = (...args) => route(...args).url()
+Vue.prototype.$route = (...args) => route(...args)
 ```
 
 ```html


### PR DESCRIPTION
This code show an error in console `TypeError: route.apply(...).url is not a function`:

```js
Vue.prototype.$route = (...args) => route(...args).url()
```

Remove `.url()` fix this issue.