### PR TITLE
Improve overflow behaviour

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -265,7 +265,7 @@ export default function Layout({ meta, children }) {
 
       {meta.sponsor && (
         <div className="bg-gray-200">
-          <div className="max-w-6xl mx-auto px-6 md:px-12 xl:px-0 py-4 flex items-center justify-start overflow-x-scroll">
+          <div className="max-w-6xl mx-auto px-6 md:px-12 xl:px-0 py-4 flex items-center justify-start overflow-x-auto">
             <div className="mr-6 text-md font-medium text-gray-600">
               <div className="md:hidden">Sponsors:</div>
               <div className="hidden md:block">Our business sponsors:</div>


### PR DESCRIPTION
There is a full-width scroll bar visible on screens wide enough for the sponsors section. Setting the overflow behaviour to auto fixes this. The scrollbar is only visible if the content exceeds the available space now.

I saw this happening a couple of times. I guess the developer was on a Mac while writing the code? The scroll bars on Macs are similar to mobile scroll bars: Invisible while not scrolling. On Windows and Linux they are always (I guess) visible. Here is a screenshot:

![image](https://user-images.githubusercontent.com/16897125/103362449-c33ea580-4ab9-11eb-9db2-19355a80807d.png)

I am on Linux Mint, Chrome 86