### PR TITLE
docs(layoutjs): correct the UsersController@index Eloquent query

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -217,7 +217,9 @@ export default function Layout({ meta, children }) {
                                 $users = User::active()
                                     ->orderByName()
                                     ->get()
-                                    ->only('id', 'name', 'email');
+                                    ->map(function ($user) {
+                                      return $user->only(['id', 'name', 'email']);
+                                    });
 
                                 return Inertia::render('Users', [
                                     'users' => $users

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -216,10 +216,7 @@ export default function Layout({ meta, children }) {
                             {
                                 $users = User::active()
                                     ->orderByName()
-                                    ->get()
-                                    ->map(function ($user) {
-                                      return $user->only(['id', 'name', 'email']);
-                                    });
+                                    ->get(['id', 'name', 'email']);
 
                                 return Inertia::render('Users', [
                                     'users' => $users


### PR DESCRIPTION
Using `only` on an Eloquent collection results in an empty collection. See https://stackoverflow.com/questions/41971901/eloquent-collections-methods-such-as-only-or-except-return-an-empty-collection.

This error can be hard to debug as an error is not thrown - an empty collection is returned.

As this is the first example on the Inertia.js docs, I recommend updating this.