### PR TITLE
Fix bug in remember docs

### DIFF
--- a/pages/remembering-state.mdx
+++ b/pages/remembering-state.mdx
@@ -144,7 +144,9 @@ If you have multiple instances of the same component on the page using the remem
         {
           remember: {
             data: ['form'],
-            key: () => \`Users/Edit:\${this.user.id}\`,
+            key: function () {
+              return \`Users/Edit:\${this.user.id}\`
+            },
           },
           data() {
             return {


### PR DESCRIPTION
The `this` context does not exist in arrow functions, so the example in the docs didn't work.