### PR TITLE
Tip to upgrade to Laravel Mix v6

### DIFF
--- a/pages/client-side-setup.mdx
+++ b/pages/client-side-setup.mdx
@@ -176,7 +176,7 @@ Next, create a `.babelrc` file in your project with the following:
   If you're using Laravel Mix v4, the dynamic imports Babel plugin is already configured. However, there is a known
   issue with Laravel Mix v4 when using dynamic imports where you cannot use styles within Vue files due to a Webpack{' '}
   <a href="https://github.com/JeffreyWay/laravel-mix/issues/1856#issuecomment-448082909">limitation</a>. As a
-  workaround, you need to drop Mix entirely or downgrade to Laravel Mix v3.
+  workaround, you need to drop Mix entirely or upgrade to Laravel Mix v6.
 </Notice>
 
 Finally, update the `resolveComponent` callback in your app initialization to use `import` instead of `require`.


### PR DESCRIPTION
Laravel Mix 6.0 has fixed the dynamic imports bug, so it's better to suggest an upgrade to v6 instead of a downgrade to v3.