### PR TITLE
Change redirect example to clarify that it uses named routes

### DIFF
--- a/pages/redirects.mdx
+++ b/pages/redirects.mdx
@@ -42,7 +42,7 @@ Inertia will automatically follow this redirect and update the page accordingly.
                         'email' => ['required', 'max:50', 'email'],
                     ])
                 );\n
-                return Redirect::route('users');
+                return Redirect::route('users.index');
             }
         }
       `,


### PR DESCRIPTION
Redirect::route() expects a named route. In the example it suggests otherwise.