### PR TITLE
Split apart Vue 2 and Vue 3 code examples

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -12,7 +12,7 @@ export const CodeTabContext = React.createContext()
 
 const getCurrentCodeTab = (tabType) => {
   const param = new URLSearchParams(location.search).get(tabType)
-  return param ? param.toLowerCase() : localStorage.getItem('tab.' + tabType)
+  return param ? param : localStorage.getItem('tab.' + tabType)
 }
 
 export default function Layout({ meta, children }) {
@@ -20,8 +20,8 @@ export default function Layout({ meta, children }) {
   const [showMobileNav, setShowMobileNav] = useState(false)
 
   const [codeTabs, setCodeTabsState] = useState({
-    frontend: 'vue.js',
-    backend: 'laravel',
+    frontend: 'Vue 3',
+    backend: 'Laravel',
   })
 
   const setCodeTabs = (value) => {
@@ -33,8 +33,8 @@ export default function Layout({ meta, children }) {
 
   useEffect(() => {
     setCodeTabs({
-      frontend: getCurrentCodeTab('frontend') || 'vue.js',
-      backend: getCurrentCodeTab('backend') || 'laravel',
+      frontend: getCurrentCodeTab('frontend') || 'Vue 3',
+      backend: getCurrentCodeTab('backend') || 'Laravel',
     })
   }, [])
 

--- a/components/TabbedCodeExamples.js
+++ b/components/TabbedCodeExamples.js
@@ -3,20 +3,20 @@ import React, { useContext, useState } from 'react'
 
 import { CodeTabContext } from './Layout'
 
-const guessTabType = tabNames => {
-  if (tabNames.includes('laravel')) {
+const guessTabType = (tabNames) => {
+  if (tabNames.includes('Laravel')) {
     return 'backend'
   }
 
-  if (tabNames.includes('vue.js')) {
+  if (tabNames.includes('Vue 3')) {
     return 'frontend'
   }
 }
 
 const TabbedCodeExamples = ({ className, examples, height }) => {
   const [codeTabs, setCodeTabs] = useContext(CodeTabContext) || useState({ unknown: 0 })
-  const tabType = guessTabType(examples.map(example => example.name.toLowerCase()))
-  const exampleIndex = examples.findIndex(example => codeTabs[tabType] === example.name.toLowerCase())
+  const tabType = guessTabType(examples.map((example) => example.name))
+  const exampleIndex = examples.findIndex((example) => codeTabs[tabType] === example.name)
   const activeTab = exampleIndex < 0 ? 0 : exampleIndex
 
   return (
@@ -26,7 +26,7 @@ const TabbedCodeExamples = ({ className, examples, height }) => {
           <button
             key={index}
             type="button"
-            onClick={() => setCodeTabs({ ...codeTabs, [tabType]: example.name.toLowerCase() })}
+            onClick={() => setCodeTabs({ ...codeTabs, [tabType]: example.name })}
             className="focus:outline-none text-sm text-gray-500 hover:text-gray-200 font-medium px-3 sm:px-6 pt-3 pb-2 rounded-t mr-1"
             css={index === activeTab ? { color: 'white', background: '#202e59' } : {}}
           >

--- a/pages/client-side-setup.mdx
+++ b/pages/client-side-setup.mdx
@@ -16,7 +16,7 @@ export const meta = {
 
 # Client-side setup
 
-Once you have your [server-side framework configured](/server-side-setup), you then need to setup your client-side framework. Inertia currently provides support for React, Vue.js, and Svelte.
+Once you have your [server-side framework configured](/server-side-setup), you then need to setup your client-side framework. Inertia currently provides support for React, Vue, and Svelte.
 
 ## Install dependencies
 
@@ -25,15 +25,19 @@ Install the Inertia client-side adapters using NPM or Yarn.
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
       language: 'bash',
       code: dedent`
-        # Vue 3
-        npm install @inertiajs/inertia @inertiajs/inertia-vue3
-        yarn add @inertiajs/inertia @inertiajs/inertia-vue3\n
-        # Vue 2
         npm install @inertiajs/inertia @inertiajs/inertia-vue
         yarn add @inertiajs/inertia @inertiajs/inertia-vue
+      `,
+    },
+    {
+      name: 'Vue 3',
+      language: 'bash',
+      code: dedent`
+        npm install @inertiajs/inertia @inertiajs/inertia-vue3
+        yarn add @inertiajs/inertia @inertiajs/inertia-vue3
       `,
     },
     {
@@ -62,28 +66,9 @@ Next, update your main JavaScript file to boot your Inertia app. All we're doing
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
       language: 'js',
       code: dedent`
-        /*
-        |----------------------------------------------------------------
-        | Vue 3
-        |----------------------------------------------------------------
-        */\n
-        import { createApp, h } from 'vue'
-        import { App, plugin } from '@inertiajs/inertia-vue3'\n
-        const el = document.getElementById('app')\n
-        createApp({
-          render: () => h(App, {
-            initialPage: JSON.parse(el.dataset.page),
-            resolveComponent: name => require(\`./Pages/\${name}\`).default,
-          })
-        }).use(plugin).mount(el)\n\n
-        /*
-        |----------------------------------------------------------------
-        | Vue 2
-        |----------------------------------------------------------------
-        */\n
         import { App, plugin } from '@inertiajs/inertia-vue'
         import Vue from 'vue'\n
         Vue.use(plugin)\n
@@ -96,6 +81,21 @@ Next, update your main JavaScript file to boot your Inertia app. All we're doing
             },
           }),
         }).$mount(el)
+      `,
+    },
+    {
+      name: 'Vue 3',
+      language: 'js',
+      code: dedent`
+        import { createApp, h } from 'vue'
+        import { App, plugin } from '@inertiajs/inertia-vue3'\n
+        const el = document.getElementById('app')\n
+        createApp({
+          render: () => h(App, {
+            initialPage: JSON.parse(el.dataset.page),
+            resolveComponent: name => require(\`./Pages/\${name}\`).default,
+          })
+        }).use(plugin).mount(el)\n\n
       `,
     },
     {
@@ -184,7 +184,14 @@ Finally, update the `resolveComponent` callback in your app initialization to us
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        resolveComponent: name => import(\`./Pages/\${name}\`).then(module => module.default),
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         resolveComponent: name => import(\`./Pages/\${name}\`).then(module => module.default),

--- a/pages/demo-application.mdx
+++ b/pages/demo-application.mdx
@@ -4,12 +4,15 @@ import Notice from '../components/Notice'
 export default Layout
 export const meta = {
   title: 'Demo application',
-  links: [{ url: '#top', name: 'Official' }, { url: '#third-party', name: 'Third party' }],
+  links: [
+    { url: '#top', name: 'Official' },
+    { url: '#third-party', name: 'Third party' },
+  ],
 }
 
 # Demo application
 
-We've setup a demo app for Inertia.js, called [Ping CRM](https://demo.inertiajs.com). This application is built using Laravel and Vue.js. You can find the source code on [GitHub](https://github.com/inertiajs/pingcrm).
+We've setup a demo app for Inertia.js, called [Ping CRM](https://demo.inertiajs.com). This application is built using Laravel and Vue. You can find the source code on [GitHub](https://github.com/inertiajs/pingcrm).
 
 <Notice>
   The Ping CRM demo is hosted on Heroku, and the database is reset every hour. Please be respectful when editing data.
@@ -19,15 +22,15 @@ We've setup a demo app for Inertia.js, called [Ping CRM](https://demo.inertiajs.
   <img className="w-full h-auto rounded" src="/pingcrm.png" alt="Ping CRM" />
 </a>
 
-In addition to the Vue.js version of Ping CRM, there is now also an officially maintained Svelte version of it, which you can find [here](https://github.com/inertiajs/pingcrm-svelte).
+In addition to the Vue version of Ping CRM, there is now also an officially maintained Svelte version of it, which you can find [here](https://github.com/inertiajs/pingcrm-svelte).
 
 ## Third party
 
 Beyond our official demo app, Ping CRM has also been translated into numerous different languages and frameworks.
 
-- [Ruby on Rails/Vue.js](https://github.com/ledermann/pingcrm/) by Georg Ledermann
+- [Ruby on Rails/Vue](https://github.com/ledermann/pingcrm/) by Georg Ledermann
 - [Laravel/React](https://github.com/Landish/pingcrm-react) by Lado Lomidze
 - [Laravel/Svelte](https://github.com/zgabievi/pingcrm-svelte) by Zura Gabievi
 - [Laravel/Mithril.js](https://github.com/tbreuss/pingcrm-mithril) by Thomas Breuss
-- [Yii 2/Vue.js](https://github.com/tbreuss/pingcrm-yii2) by Thomas Breuss
-- [Symfony/Vue.js](https://github.com/aleksblendwerk/pingcrm-symfony) by Aleks Seltenreich
+- [Yii 2/Vue](https://github.com/tbreuss/pingcrm-yii2) by Thomas Breuss
+- [Symfony/Vue](https://github.com/aleksblendwerk/pingcrm-symfony) by Aleks Seltenreich

--- a/pages/error-handling.mdx
+++ b/pages/error-handling.mdx
@@ -6,7 +6,10 @@ import TabbedCodeExamples from '../components/TabbedCodeExamples'
 export default Layout
 export const meta = {
   title: 'Error handling',
-  links: [{ url: '#development', name: 'Development' }, { url: '#production', name: 'Production' }],
+  links: [
+    { url: '#development', name: 'Development' },
+    { url: '#production', name: 'Production' },
+  ],
 }
 
 # Error handling
@@ -79,7 +82,44 @@ Notice how we're returning an `Error` page component in the example above. You'l
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <div>
+            <h1>{{ title }}</h1>
+            <div>{{ description }}</div>
+          </div>
+        </template>\n
+        <script>
+        export default {
+          props: {
+            status: Number,
+          },
+          computed: {
+            title() {
+              return {
+                503: '503: Service Unavailable',
+                500: '500: Server Error',
+                404: '404: Page Not Found',
+                403: '403: Forbidden',
+              }[this.status]
+            },
+            description() {
+              return {
+                503: 'Sorry, we are doing some maintenance. Please check back soon.',
+                500: 'Whoops, something went wrong on our servers.',
+                404: 'Sorry, the page you are looking for could not be found.',
+                403: 'Sorry, you are forbidden from accessing this page.',
+              }[this.status]
+            },
+          },
+        }
+        </script>
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'twig',
       code: dedent`
         <template>

--- a/pages/forms.mdx
+++ b/pages/forms.mdx
@@ -24,7 +24,42 @@ While it's possible to make classic form submissions with Inertia, it's not reco
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <form @submit.prevent="submit">
+            <label for="first_name">First name:</label>
+            <input id="first_name" v-model="form.first_name" />
+            <label for="last_name">Last name:</label>
+            <input id="last_name" v-model="form.last_name" />
+            <label for="email">Email:</label>
+            <input id="email" v-model="form.email" />
+            <button type="submit">Submit</button>
+          </form>
+        </template>\n
+        <script>
+        export default {
+          data() {
+            return {
+              form: {
+                first_name: null,
+                last_name: null,
+                email: null,
+              },
+            }
+          },
+          methods: {
+            submit() {
+              this.$inertia.post('/users', this.form)
+            },
+          },
+        }
+        </script>
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'twig',
       code: dedent`
         <template>
@@ -202,7 +237,7 @@ Since working with forms is so common, Inertia comes with a form helper designed
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
       language: 'twig',
       code: dedent`
         <template>
@@ -220,27 +255,6 @@ Since working with forms is so common, Inertia comes with a form helper designed
           </form>
         </template>\n
         <script>
-        /*
-        |----------------------------------------------------------------
-        | Vue 3
-        |----------------------------------------------------------------
-        */\n
-        import { useForm } from '@inertiajs/inertia-vue3'\n
-        export default {
-          setup () {
-            const form = useForm({
-              email: null,
-              password: null,
-              remember: false,
-            })\n
-            return { form }
-          },
-        }\n
-        /*
-        |----------------------------------------------------------------
-        | Vue 2
-        |----------------------------------------------------------------
-        */\n
         export default {
           data() {
             return {
@@ -250,6 +264,39 @@ Since working with forms is so common, Inertia comes with a form helper designed
                 remember: false,
               }),
             }
+          },
+        }
+        </script>
+      `,
+    },
+    {
+      name: 'Vue 3',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <form @submit.prevent="form.post('/login')">
+            <!-- email -->
+            <input type="text" v-model="form.email">
+            <div v-if="form.errors.email">{{ form.errors.email }}</div>
+            <!-- password -->
+            <input type="password" v-model="form.password">
+            <div v-if="form.errors.password">{{ form.errors.password }}</div>
+            <!-- remember me -->
+            <input type="checkbox" v-model="form.remember"> Remember Me
+            <!-- submit -->
+            <button type="submit" :disabled="form.processing">Login</button>
+          </form>
+        </template>\n
+        <script>
+        import { useForm } from '@inertiajs/inertia-vue3'\n
+        export default {
+          setup () {
+            const form = useForm({
+              email: null,
+              password: null,
+              remember: false,
+            })\n
+            return { form }
           },
         }
         </script>
@@ -297,7 +344,18 @@ To submit the form, use the `get`, `post`, `put`, `patch` and `delete` methods.
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        form.get(url, options)
+        form.post(url, options)
+        form.put(url, options)
+        form.patch(url, options)
+        form.delete(url, options)
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         form.get(url, options)
@@ -334,7 +392,17 @@ The submit methods support all the regular [visit options](/manual-visits), such
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        form.post('/profile', {
+          preserveScroll: true,
+          onSuccess: () => form.reset('password'),
+        })
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         form.post('/profile', {
@@ -369,7 +437,19 @@ If you need to modify the form data before it's sent to the server, you can do t
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        form
+          .transform((data) => ({
+            ...data,
+            remember: data.remember ? 'on' : '',
+          }))
+          .post('/login')
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         form
@@ -406,7 +486,14 @@ You can use the `processing` property to track if a form is currently being subm
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <button type="submit" :disabled="form.processing">Submit</button>
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <button type="submit" :disabled="form.processing">Submit</button>
@@ -435,7 +522,16 @@ In the event that you're uploading files, the current progress event is availabl
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <progress v-if="form.progress" :value="form.progress.percentage" max="100">
+          {{ form.progress.percentage }}%
+        </progress>
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <progress v-if="form.progress" :value="form.progress.percentage" max="100">
@@ -470,7 +566,14 @@ In the event there are form errors, they are available via the `errors` property
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <div v-if="form.errors.email">{{ form.errors.email }}</div>
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <div v-if="form.errors.email">{{ form.errors.email }}</div>
@@ -499,7 +602,17 @@ To check if a form has any errors, use the `hasErrors` property. To clear form e
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        // Clear all errors
+        form.clearErrors()\n
+        // Clear errors for specific fields
+        form.clearErrors('field', 'anotherfield')
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         // Clear all errors
@@ -536,7 +649,17 @@ To reset the form values back to their original values, use the `reset()` method
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        // Reset the form
+        form.reset()\n
+        // Reset specific fields
+        form.reset('field', 'anotherfield')
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         // Reset the form

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -26,7 +26,7 @@ See the [who is it for](/who-is-it-for) and [how it works](/how-it-works) pages 
 
 ## Not a framework
 
-Inertia isn't a framework, nor is it a replacement to your existing server-side or client-side frameworks. Rather, it's designed to work with them. Think of Inertia as glue that connects the two. Inertia does this via adapters. We currently have three official client-side adapters (React, Vue.js, and Svelte) and two server-side adapters (Laravel and Rails).
+Inertia isn't a framework, nor is it a replacement to your existing server-side or client-side frameworks. Rather, it's designed to work with them. Think of Inertia as glue that connects the two. Inertia does this via adapters. We currently have three official client-side adapters (React, Vue, and Svelte) and two server-side adapters (Laravel and Rails).
 
 ## Join the newsletter
 

--- a/pages/links.mdx
+++ b/pages/links.mdx
@@ -30,7 +30,15 @@ To create an Inertia link, use the Inertia link component. Note, any attributes 
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <inertia-link href="/">Home</inertia-link>
+      `,
+      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <inertia-link href="/">Home</inertia-link>
@@ -63,7 +71,16 @@ By default Inertia renders links as anchor `<a>` elements. However, you can chan
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <inertia-link href="/logout" method="post" as="button" type="button">Logout</inertia-link>\n
+        // Renders as:
+        <button type="button">Logout</button>
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <inertia-link href="/logout" method="post" as="button" type="button">Logout</inertia-link>\n
@@ -110,7 +127,15 @@ You can specify the method for an Inertia link request. The default is `GET`, bu
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <inertia-link href="/logout" method="post">Logout</inertia-link>
+      `,
+      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <inertia-link href="/logout" method="post">Logout</inertia-link>
@@ -144,7 +169,15 @@ You can add data using the `data` attribute. This can be an `object`, or a `Form
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <inertia-link href="/endpoint" method="post" :data="{ foo: bar }">Save</inertia-link>
+      `,
+      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <inertia-link href="/endpoint" method="post" :data="{ foo: bar }">Save</inertia-link>
@@ -177,7 +210,15 @@ The `headers` option allows you to add custom headers to an Inertia link. Do not
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <inertia-link href="/endpoint" :headers="{ foo: bar }">Save</inertia-link>
+      `,
+      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <inertia-link href="/endpoint" :headers="{ foo: bar }">Save</inertia-link>
@@ -211,7 +252,15 @@ You can specify the browser history behaviour. By default page visits push (new)
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <inertia-link href="/" replace>Home</inertia-link>
+      `,
+      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <inertia-link href="/" replace>Home</inertia-link>
@@ -245,7 +294,16 @@ You can preserve a page component's local state using the `preserve-state` attri
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <input v-model="query" type="text" />\n
+        <inertia-link href="/search" :data="{ query }" preserve-state>Search</inertia-link>
+      `,
+      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <input v-model="query" type="text" />\n
@@ -282,7 +340,15 @@ You can use the `preserve-scroll` attribute to prevent Inertia from automaticall
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <inertia-link href="/" preserve-scroll>Home</inertia-link>
+      `,
+      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <inertia-link href="/" preserve-scroll>Home</inertia-link>
@@ -318,7 +384,15 @@ The `only` option allows you to request a subset of the props (data) from the se
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <inertia-link href="/users?active=true" :only="['users']">Show active</inertia-link>
+      `,
+      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <inertia-link href="/users?active=true" :only="['users']">Show active</inertia-link>

--- a/pages/manual-visits.mdx
+++ b/pages/manual-visits.mdx
@@ -28,7 +28,32 @@ In addition to [creating links](/links), it's also possible to manually make Ine
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        // import { Inertia } from '@inertiajs/inertia'\n
+        this.$inertia.visit(url, {
+          method: 'get',
+          data: {},
+          replace: false,
+          preserveState: false,
+          preserveScroll: false,
+          only: [],
+          headers: {},
+          errorBag: null,
+          onCancelToken: cancelToken => {},
+          onCancel: () => {},
+          onBefore: visit => {},
+          onStart: visit => {},
+          onProgress: progress => {},
+          onSuccess: page => {},
+          onError: errors => {},
+          onFinish: () => {},
+        })
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         // import { Inertia } from '@inertiajs/inertia'\n
@@ -110,7 +135,21 @@ However, generally it's preferred to use one of the shortcut methods instead. Th
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        // import { Inertia } from '@inertiajs/inertia'\n
+        this.$inertia.get(url, data, options)
+        this.$inertia.post(url, data, options)
+        this.$inertia.put(url, data, options)
+        this.$inertia.patch(url, data, options)
+        this.$inertia.delete(url, options)
+        this.$inertia.replace(url, options)
+        this.$inertia.reload(options) // Uses the current URL
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         // import { Inertia } from '@inertiajs/inertia'\n

--- a/pages/pages.mdx
+++ b/pages/pages.mdx
@@ -26,7 +26,30 @@ Pages are simply JavaScript components. There is nothing particularly special ab
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <layout title="Welcome">
+            <h1>Welcome</h1>
+            <p>Hello {{ user.name }}, welcome to your first Inertia app!</p>
+          </layout>
+        </template>\n
+        <script>
+          import Layout from './Layout'\n
+          export default {
+            components: {
+              Layout,
+            },
+            props: {
+              user: Object,
+            },
+          }
+        </script>
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'twig',
       code: dedent`
         <template>
@@ -88,7 +111,41 @@ While not required, for most projects it makes sense to create a site layout tha
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <main>
+            <header>
+              <inertia-link href="/">Home</inertia-link>
+              <inertia-link href="/about">About</inertia-link>
+              <inertia-link href="/contact">Contact</inertia-link>
+            </header>
+            <article>
+              <slot />
+            </article>
+          </main>
+        </template>\n
+        <script>
+          export default {
+            props: {
+              title: String,
+            },
+            watch: {
+              title: {
+                immediate: true,
+                handler(title) {
+                  document.title = title
+                },
+              },
+            },
+          }
+        </script>
+      `,
+      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
+    },
+    {
+      name: 'Vue 3',
       language: 'twig',
       code: dedent`
         <template>
@@ -179,7 +236,31 @@ For example, maybe you have an audio player on a podcast website that you want t
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <div>
+            <h1>Welcome</h1>
+            <p>Hello {{ user.name }}, welcome to your first Inertia app!</p>
+          </div>
+        </template>\n
+        <script>
+          import Layout from './Layout'\n
+          export default {
+            // Using a render function
+            layout: (h, page) => h(Layout, [page]),\n
+            // Using the shorthand
+            layout: Layout,\n
+            props: {
+              user: Object,
+            },
+          }
+        </script>
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'twig',
       code: dedent`
         <template>
@@ -243,7 +324,36 @@ You can also create more complex layout arrangements using nested layouts.
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <div>
+            <h1>Welcome</h1>
+            <p>Hello {{ user.name }}, welcome to your first Inertia app!</p>
+          </div>
+        </template>\n
+        <script>
+          import SiteLayout from './SiteLayout'
+          import NestedLayout from './NestedLayout'\n
+          export default {
+            // Using a render function
+            layout: (h, page) => {
+              return h(SiteLayout, [
+                h(NestedLayout, [page]),
+              ])
+            },\n
+            // Using the shorthand
+            layout: [SiteLayout, NestedLayout],\n
+            props: {
+              user: Object,
+            },
+          }
+        </script>
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'twig',
       code: dedent`
         <template>
@@ -320,7 +430,21 @@ If you're using persistent layouts, it's possible to set a default page layout i
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        import Layout from './Layout'\n
+        resolveComponent: name => import(\`./Pages/\${name}\`)
+          .then(({ default: page }) => {
+            if (page.layout === undefined) {
+              page.layout = Layout
+            }
+            return page
+          }),
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         import Layout from './Layout'\n
@@ -371,7 +495,21 @@ You can even go a step further and conditionally set the default page layout bas
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        import Layout from './Layout'\n
+        resolveComponent: name => import(\`./Pages/\${name}\`)
+          .then(({ default: page }) => {
+            if (page.layout === undefined && !name.startsWith('Public/')) {
+              page.layout = Layout
+            }
+            return page
+          }),
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         import Layout from './Layout'\n
@@ -422,7 +560,36 @@ While it's possible to pass title and meta tag props from pages to layouts (as i
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <layout>
+            <h1>Welcome</h1>
+            <p>Hello {{ user.name }}, welcome to your first Inertia app!</p>
+          </layout>
+        </template>\n
+        <script>
+          import Layout from './Layout'\n
+          export default {
+            metaInfo() {
+              return {
+                title: \`Welcome \${this.user.name}\`,
+              }
+            },
+            components: {
+              Layout,
+            },
+            props: {
+              user: Object,
+            },
+          }
+        </script>
+      `,
+      description: "Don't forget to install and configure the Vue Meta package.",
+    },
+    {
+      name: 'Vue 3',
       language: 'twig',
       code: dedent`
         <template>

--- a/pages/partial-reloads.mdx
+++ b/pages/partial-reloads.mdx
@@ -46,7 +46,15 @@ It's also possible to perform partial reloads with Inertia links using the `only
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'twig',
+      code: dedent`
+        <inertia-link href="/users?active=true" :only="['users']">Show active</inertia-link>
+      `,
+      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
+    },
+    {
+      name: 'Vue 3',
       language: 'twig',
       code: dedent`
         <inertia-link href="/users?active=true" :only="['users']">Show active</inertia-link>
@@ -127,4 +135,3 @@ When Inertia performs a visit, it will determine which data is required, and onl
     },
   ]}
 />
-

--- a/pages/releases/inertia-0.1.0.mdx
+++ b/pages/releases/inertia-0.1.0.mdx
@@ -46,7 +46,7 @@ import { InertiaApp } from '@inertiajs/inertia-vue'
 import { InertiaApp } from '@inertiajs/inertia-react'
 ```
 
-If you're using Vue.js, you'll need to update the plugin:
+If you're using Vue, you'll need to update the plugin:
 
 ```js
 // Before

--- a/pages/releases/inertia-vue-0.2.1.mdx
+++ b/pages/releases/inertia-vue-0.2.1.mdx
@@ -9,4 +9,4 @@ export const meta = {
 
 <div className="-mt-8 mb-12 text-base font-medium text-gray-600">Published on September 1, 2020</div>
 
-- Add the ability to pass root template slots to Vue.js ([#198](https://github.com/inertiajs/inertia/pull/198)).
+- Add the ability to pass root template slots to Vue ([#198](https://github.com/inertiajs/inertia/pull/198)).

--- a/pages/remembering-state.mdx
+++ b/pages/remembering-state.mdx
@@ -5,7 +5,10 @@ import TabbedCodeExamples from '../components/TabbedCodeExamples'
 export default Layout
 export const meta = {
   title: 'Remembering state',
-  links: [{ url: '#top', name: 'Introduction' }, { url: '#multiple-components', name: 'Multiple components' }],
+  links: [
+    { url: '#top', name: 'Introduction' },
+    { url: '#multiple-components', name: 'Multiple components' },
+  ],
 }
 
 # Remembering state
@@ -19,7 +22,33 @@ To mitigate this issue, you can tell Inertia which local component state to save
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      description: 'Use the "remember" property.',
+      language: 'js',
+      code: dedent`
+        {
+          // Option 1: Object
+          remember: {
+            data: ['form'],
+          },\n
+          // Option 2: Array
+          remember: ['form'],\n
+          // Option 3: String
+          remember: 'form',\n
+          data() {
+            return {
+              form: {
+                first_name: null,
+                last_name: null,
+                // ...
+              },
+            }
+          },
+        }
+      `,
+    },
+    {
+      name: 'Vue 3',
       description: 'Use the "remember" property.',
       language: 'js',
       code: dedent`
@@ -86,7 +115,27 @@ If your page contains multiple components that use the remember functionality, y
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        {
+          remember: {
+            data: ['form'],
+            key: 'Users/Create',
+          },
+          data() {
+            return {
+              form: {
+                first_name: null,
+                last_name: null,
+              },
+            }
+          },
+        }
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         {
@@ -138,7 +187,27 @@ If you have multiple instances of the same component on the page using the remem
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        {
+          remember: {
+            data: ['form'],
+            key: () => \`Users/Edit:\${this.user.id}\`,
+          },
+          data() {
+            return {
+              form: {
+                first_name: this.user.first_name,
+                last_name: this.user.last_name,
+              },
+            }
+          },
+        }
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         {

--- a/pages/routing.mdx
+++ b/pages/routing.mdx
@@ -103,7 +103,7 @@ Another option is to make your route definitions available client-side as JSON, 
 </script>
 ```
 
-If you're using Laravel, the <a href="https://github.com/tightenco/ziggy">Ziggy</a> library does this for you automatically via a global `route()` function. If you're using Ziggy with Vue.js, it's helpful to make this function available as a custom `$route` property so you can use it directly in your templates.
+If you're using Laravel, the <a href="https://github.com/tightenco/ziggy">Ziggy</a> library does this for you automatically via a global `route()` function. If you're using Ziggy with Vue, it's helpful to make this function available as a custom `$route` property so you can use it directly in your templates.
 
 ```js
 Vue.prototype.$route = route

--- a/pages/scroll-management.mdx
+++ b/pages/scroll-management.mdx
@@ -39,7 +39,15 @@ You can also preserve the scroll position with [Inertia links](/links) using the
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'jsx',
+      code: dedent`
+        <inertia-link href="/" preserve-scroll>Home</inertia-link>
+      `,
+      description: 'The <inertia-link> component is automatically registered by the Inertia plugin.',
+    },
+    {
+      name: 'Vue 3',
       language: 'jsx',
       code: dedent`
         <inertia-link href="/" preserve-scroll>Home</inertia-link>

--- a/pages/shared-data.mdx
+++ b/pages/shared-data.mdx
@@ -96,7 +96,7 @@ Once you've shared the data server-side, you'll then be able to access it within
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
       description: 'Access shared data using the $page property or the usePage() hook.',
       language: 'twig',
       code: dedent`
@@ -117,11 +117,38 @@ Once you've shared the data server-side, you'll then be able to access it within
           </main>
         </template>\n
         <script>
-          /*
-          |----------------------------------------------------------------
-          | Vue 3
-          |----------------------------------------------------------------
-          */\n
+          export default {
+            computed: {
+              user() {
+                return this.$page.props.auth.user
+              }
+            }
+          }
+        </script>
+      `,
+    },
+    {
+      name: 'Vue 3',
+      description: 'Access shared data using the $page property or the usePage() hook.',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <main>
+            <header>
+              <div>You are logged in as: {{ user.name }}</div>
+              <nav>
+                <inertia-link href="/">Home</inertia-link>
+                <inertia-link href="/about">About</inertia-link>
+                <inertia-link href="/contact">Contact</inertia-link>
+              </nav>
+            </header>
+            <content>
+              <slot />
+            </content>
+            <footer></footer>
+          </main>
+        </template>\n
+        <script>
           import { computed } from 'vue'
           import { usePage } from '@inertiajs/inertia-vue3'\n
           export default {
@@ -129,18 +156,6 @@ Once you've shared the data server-side, you'll then be able to access it within
               const user = computed(() => usePage().props.value.auth.user)
               return { user }
             },
-          }\n
-          /*
-          |----------------------------------------------------------------
-          | Vue 2
-          |----------------------------------------------------------------
-          */\n
-          export default {
-            computed: {
-              user() {
-                return this.$page.props.auth.user
-              }
-            }
           }
         </script>
       `,
@@ -243,7 +258,25 @@ Next, display the flash message in a front-end component, such as the site layou
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <main>
+            <header></header>
+            <content>
+              <div v-if="$page.props.flash.message" class="alert">
+                {{ $page.props.flash.message }}
+              </div>
+              <slot />
+            </content>
+            <footer></footer>
+          </main>
+        </template>
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'twig',
       code: dedent`
         <template>

--- a/pages/sponsors.mdx
+++ b/pages/sponsors.mdx
@@ -278,8 +278,8 @@ A huge thanks to our business sponsors, whose significant support helps push Ine
     </svg>
   </a>
   <div className="mt-4 text-sm leading-normal">
-    Visually design and code Vue.js apps solo or with your team. Includes realtime designer/developer collaboration,
-    pair programming, and a Tailwind based design system.
+    Visually design and code Vue apps solo or with your team. Includes realtime designer/developer collaboration, pair
+    programming, and a Tailwind based design system.
   </div>
 </div>
 

--- a/pages/transforming-props.mdx
+++ b/pages/transforming-props.mdx
@@ -12,7 +12,27 @@ Sometimes it can be useful to transform the props client-side before they are pa
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        new Vue({
+          render: h => h(App, {
+            props: {
+              initialPage: JSON.parse(el.dataset.page),
+              resolveComponent: name => require(\`./Pages/\${name}\`).default,
+              transformProps: props => {
+                return {
+                  ...props,
+                  errors: new Errors(props.errors),
+                }
+              },
+            },
+          }),
+        }).$mount(el)
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'js',
       code: dedent`
         new Vue({

--- a/pages/validation.mdx
+++ b/pages/validation.mdx
@@ -91,7 +91,48 @@ Since validation errors are made available client-side as page component props, 
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
+      language: 'twig',
+      code: dedent`
+        <template>
+          <form @submit.prevent="submit">
+            <label for="first_name">First name:</label>
+            <input id="first_name" v-model="form.first_name" />
+            <div v-if="errors.first_name">{{ errors.first_name }}</div>
+            <label for="last_name">Last name:</label>
+            <input id="last_name" v-model="form.last_name" />
+            <div v-if="errors.last_name">{{ errors.last_name }}</div>
+            <label for="email">Email:</label>
+            <input id="email" v-model="form.email" />
+            <div v-if="errors.email">{{ errors.email }}</div>
+            <button type="submit">Submit</button>
+          </form>
+        </template>\n
+        <script>
+        export default {
+          props: {
+            errors: Object,
+          },
+          data() {
+            return {
+              form: {
+                first_name: null,
+                last_name: null,
+                email: null,
+              },
+            }
+          },
+          methods: {
+            submit() {
+              this.$inertia.post('/users', this.form)
+            },
+          },
+        }
+        </script>
+      `,
+    },
+    {
+      name: 'Vue 3',
       language: 'twig',
       code: dedent`
         <template>
@@ -224,29 +265,9 @@ If your application shares errors using a different prop than `errors`, you must
 <TabbedCodeExamples
   examples={[
     {
-      name: 'Vue.js',
+      name: 'Vue 2',
       language: 'js',
       code: dedent`
-        /*
-        |----------------------------------------------------------------
-        | Vue 3
-        |----------------------------------------------------------------
-        */\n
-        import { createApp, h } from 'vue'
-        import { App, plugin } from '@inertiajs/inertia-vue3'\n
-        const el = document.getElementById('app')\n
-        createApp({
-          render: () => h(App, {
-            initialPage: JSON.parse(el.dataset.page),
-            resolveComponent: name => require(\`./Pages/\${name}\`).default,
-            resolveErrors: page => (page.props.errors || {}),
-          })
-        }).use(plugin).mount(el)\n\n
-        /*
-        |----------------------------------------------------------------
-        | Vue 2
-        |----------------------------------------------------------------
-        */\n
         import { App, plugin } from '@inertiajs/inertia-vue'
         import Vue from 'vue'\n
         Vue.use(plugin)\n
@@ -260,6 +281,22 @@ If your application shares errors using a different prop than `errors`, you must
             },
           }),
         }).$mount(el)
+      `,
+    },
+    {
+      name: 'Vue 3',
+      language: 'js',
+      code: dedent`
+        import { createApp, h } from 'vue'
+        import { App, plugin } from '@inertiajs/inertia-vue3'\n
+        const el = document.getElementById('app')\n
+        createApp({
+          render: () => h(App, {
+            initialPage: JSON.parse(el.dataset.page),
+            resolveComponent: name => require(\`./Pages/\${name}\`).default,
+            resolveErrors: page => (page.props.errors || {}),
+          })
+        }).use(plugin).mount(el)\n\n
       `,
     },
     {


### PR DESCRIPTION
This PR splits apart the Vue 2 and Vue 3 code examples. Getting these both under the "Vue.js" tab was difficult, and not very clear. There is a little more duplication this way, but I'm totally okay with that. Plus, we now have an opportunity to tailor the Vue 3 examples to the new composition API.

## Before

![image](https://user-images.githubusercontent.com/882133/112408056-78fe4680-8ced-11eb-9cf1-e9d255a0c39e.png)

## After

![image](https://user-images.githubusercontent.com/882133/112408006-671ca380-8ced-11eb-9179-4fa11ee67460.png)
