### PR TITLE
Fix this.user to props.user in Vue 3 example.

### DIFF
--- a/pages/remembering-state.mdx
+++ b/pages/remembering-state.mdx
@@ -218,11 +218,11 @@ If you have multiple instances of the same component on the page using the remem
       code: dedent`
         import { useRemember } from '@inertiajs/inertia-vue3'\n
         export default {
-          setup() {
+          setup(props) {
             const form = useRemember({
                 first_name: null,
                 last_name: null,
-            }, \`Users/Edit:\${this.user.id}\`)\n
+            }, \`Users/Edit:\${props.user.id}\`)\n
             return { form }
           },
         }


### PR DESCRIPTION
Because `setup` method in Vue 3 do not access to `this` instance, then we getting error: `TypeError: Cannot read property 'user' of undefined`.