### PR TITLE
Rails docs: Add example for sharing errors

### DIFF
--- a/pages/validation.mdx
+++ b/pages/validation.mdx
@@ -78,7 +78,16 @@ In order for your server-side validation errors to be available client-side, you
       name: 'Rails',
       language: 'ruby',
       code: dedent`
-        # todo
+        class UsersController < ApplicationController
+          def create
+            user = User.create(user_params)\n
+            if user.persisted?
+              redirect_to users_path
+            else
+              redirect_to new_user_path, inertia: { errors: user.errors }
+            end
+          end
+        end
       `,
     },
   ]}


### PR DESCRIPTION
This PR adds an example of sharing errors between Rails and client-side.

The original feature was implemented in https://github.com/inertiajs/inertia-rails/pull/50