### PR TITLE
Allow for better error handling on Laravel Dusk

### DIFF
--- a/pages/error-handling.mdx
+++ b/pages/error-handling.mdx
@@ -54,7 +54,7 @@ In production you'll want to return a proper Inertia error response instead of r
         public function render($request, Throwable $e)
         {
             $response = parent::render($request, $e);\n
-            if (!app()->environment('local') && in_array($response->status(), [500, 503, 404, 403])) {
+            if (!app()->environment(['local', 'testing']) && in_array($response->status(), [500, 503, 404, 403])) {
                 return Inertia::render('Error', ['status' => $response->status()])
                     ->toResponse($request)
                     ->setStatusCode($response->status());


### PR DESCRIPTION
When using Laravel Dusk, the environment is typically set to 'testing' even though it runs in the browser. By adding support for the 'testing' as well as 'local' environments, Laravel Dusk will be able to screenshot Inertia's properly rendered modal containing the error response.