### PR TITLE
Fix React Example

### DIFF
--- a/pages/client-side-setup.mdx
+++ b/pages/client-side-setup.mdx
@@ -102,12 +102,12 @@ Next, update your main JavaScript file to boot your Inertia app. All we're doing
       name: 'React',
       language: 'jsx',
       code: dedent`
-        import { App } from '@inertiajs/inertia-react'
+        import { InertiaApp } from '@inertiajs/inertia-react'
         import React from 'react'
         import { render } from 'react-dom'\n
         const el = document.getElementById('app')\n
         render(
-          <App
+          <InertiaApp
             initialPage={JSON.parse(el.dataset.page)}
             resolveComponent={name => require(\`./Pages/\${name}\`).default}
           />,


### PR DESCRIPTION
This fixes the React Example on https://inertiajs.com/client-side-setup

Currently the example is using the type "App" instead of the exported const "InertiaApp".

When using App it causes this error.
![image](https://user-images.githubusercontent.com/28160910/114919857-ae93dc80-9e20-11eb-8647-6551032a9ef4.png)
