### PR TITLE
Added line for yarn add @babel/plugin-syntax-dynamic-import

### DIFF
--- a/pages/client-side-setup.mdx
+++ b/pages/client-side-setup.mdx
@@ -162,6 +162,7 @@ To use code splitting with Inertia you'll need to enable [dynamic imports](https
 
 ```bash
 npm install @babel/plugin-syntax-dynamic-import
+yarn add @babel/plugin-syntax-dynamic-import
 ```
 
 Next, create a `.babelrc` file in your project with the following:


### PR DESCRIPTION
Everywhere else on the page has both npm install and yarn add so you can copy/paste. Added missing one for consistency