### PR TITLE
Updated "Routing" docs to have Vue 3 version of global function registration

### DIFF
--- a/pages/routing.mdx
+++ b/pages/routing.mdx
@@ -105,9 +105,27 @@ Another option is to make your route definitions available client-side as JSON, 
 
 If you're using Laravel, the <a href="https://github.com/tightenco/ziggy">Ziggy</a> library does this for you automatically via a global `route()` function. If you're using Ziggy with Vue, it's helpful to make this function available as a custom `$route` property so you can use it directly in your templates.
 
-```js
-Vue.prototype.$route = route
-```
+<TabbedCodeExamples
+  examples={[
+    {
+      name: 'Vue 2',
+      language: 'js',
+      code: dedent`
+        Vue.prototype.$route = route
+      `,
+    },
+    {
+      name: 'Vue 3',
+      language: 'js',
+      code: dedent`
+        const app = createApp({
+          // init app and resolve components...
+        })
+        app.config.globalProperties.$route = route
+      `,
+    }
+  ]}
+/>
 
 ```html
 <inertia-link :href="$route('users.create')">Create User</inertia-link>


### PR DESCRIPTION
Vue 3 changed how global function registration. Updated routing docs to have both Vue 2 and Vue 3 versions.

Official Vue 3 docs for reference: [Vue.prototype Replaced by config.globalProperties](https://v3.vuejs.org/guide/migration/global-api.html#vue-prototype-replaced-by-config-globalproperties)