### PR TITLE
Mistake on line 273 in Pages.js

### DIFF
--- a/resources/js/Pages/pages.js
+++ b/resources/js/Pages/pages.js
@@ -270,7 +270,7 @@ const Page = () => {
                 import Layout from './Layout'\n
                 export default {
                   // Using a render function
-                  layout: (h, page) => h(Layout, () => child),\n
+                  layout: (h, page) => h(Layout, () => page),\n
                   // Using the shorthand
                   layout: Layout,\n
                   props: {


### PR DESCRIPTION
This code doesn't work:
layout: (h, page) => h(Layout, () => child),

child is undefined
It should be:

layout: (h, page) => h(Layout, () => page),