### PR TITLE
Update pushState limit for Firefox

### DIFF
--- a/resources/js/Pages/responses.js
+++ b/resources/js/Pages/responses.js
@@ -143,7 +143,7 @@ const Page = () => {
         To enable client-side history navigation, all Inertia server responses are stored in the browser's history
         state. It's good to be aware that some browsers impose a size limit on how much data can be saved there. For
         example, <A href="https://developer.mozilla.org/en-US/docs/Web/API/History/pushState">Firefox</A> has a size
-        limit of 640k characters (and throws a <Code>NS_ERROR_ILLEGAL_VALUE</Code> error if you exceed it). This is
+        limit of 2M characters (and throws a <Code>NS_ERROR_ILLEGAL_VALUE</Code> error if you exceed it). This is
         generally much more than you'll ever need, but it's good to be aware of this when building an Inertia
         application.
       </P>


### PR DESCRIPTION
This PR fixes https://github.com/inertiajs/inertiajs.com/issues/226.

It updates the documented limit for the pushState function since it changed a while ago.

---

The documentation changed on 24 Jan 2021 in commit https://github.com/mdn/content/commit/21e72af0578091c8015ff46ec4426697ebf43210.

As far as I can tell, the modification landed in Firefox about three years ago, following this bug report.

https://bugzilla.mozilla.org/show_bug.cgi?id=1542673

https://hg.mozilla.org/mozilla-central/rev/49205d157f4d
