### PR TITLE
Update Django server-side adapter link

### DIFF
--- a/resources/js/Pages/community-adapters.js
+++ b/resources/js/Pages/community-adapters.js
@@ -39,7 +39,7 @@ const Page = () => {
           <A href="https://github.com/elpete/cbInertia">ColdBox</A>
         </Li>
         <Li>
-          <A href="https://pypi.org/project/inertia-django/">Django</A>
+          <A href="https://github.com/girardinsamuel/django-inertia">Django</A>
         </Li>
         <Li>
           <A href="https://github.com/petaki/inertia-go">Go</A>


### PR DESCRIPTION
Hi !

I took over the Django Inertia.js adapter as the [previous one](https://github.com/zodman/inertia-django) was not maintained anymore by [Andres Vargas](https://github.com/zodman).

I am opening this PR to update the link on the community adapters page.

Is this okay with you ?

Thanks 🙏 