### PR TITLE
fix a link to manual-visits

### DIFF
--- a/resources/js/Pages/scroll-management.js
+++ b/resources/js/Pages/scroll-management.js
@@ -25,7 +25,7 @@ const Page = () => {
       <H2>Scroll preservation</H2>
       <P>
         Sometimes it's desirable to prevent the default scroll resetting when making visits. You can disable this
-        behaviour using the <Code>preserveScroll</Code> option when manually <A href="/requests">making visits</A>.
+        behaviour using the <Code>preserveScroll</Code> option when manually <A href="/manual-visits">making visits</A>.
       </P>
       <CodeBlock
         language="js"


### PR DESCRIPTION
The link to `Manual visits` page was broken, so this PR update the link to the correct page.

This PR should close #238 once it is merged.