### PR TITLE
Remove maximum-scale from example code viewport meta tag

### DIFF
--- a/resources/js/Pages/server-side-rendering.js
+++ b/resources/js/Pages/server-side-rendering.js
@@ -265,7 +265,7 @@ const Page = () => {
           <html>
             <head>
               <meta charset="utf-8" />
-              <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+              <meta name="viewport" content="width=device-width, initial-scale=1.0" />
               <link href="{{ mix('/css/app.css') }}" rel="stylesheet">
               <script src="{{ mix('/js/app.js') }}" defer></script>
               @inertiaHead

--- a/resources/js/Pages/server-side-setup.js
+++ b/resources/js/Pages/server-side-setup.js
@@ -62,7 +62,7 @@ const Page = () => {
               <html>
                 <head>
                   <meta charset="utf-8" />
-                  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+                  <meta name="viewport" content="width=device-width, initial-scale=1.0 />
                   <link href="{{ mix('/css/app.css') }}" rel="stylesheet" />
                   <script src="{{ mix('/js/app.js') }}" defer></script>
                   @inertiaHead


### PR DESCRIPTION
The example code contains `maximum-scale=1.0` in the viewport meta tag. This setting isn't good for UX or A11Y for users that need to be able to zoom pages.

Although developers may not copy this code exactly I think it'd be better not to demonstrate a less accessible default.