### PR TITLE
Fix typo in `server-side-rendering`

### DIFF
--- a/resources/js/Pages/server-side-rendering.js
+++ b/resources/js/Pages/server-side-rendering.js
@@ -344,7 +344,7 @@ const Page = () => {
       </Notice>
       <H2 id="running-the-service">Running the Node.js service</H2>
       <P>
-        With the builds generated, you should be able run the Node server using the following command:
+        With the builds generated, you should be able to run the Node server using the following command:
       </P>
       <CodeBlock
         language="bash"


### PR DESCRIPTION
This PR fixes a small typo on the `server-side-rendering` page.