### PR TITLE
docs: :memo: Improve default layout example

### DIFF
--- a/resources/js/Pages/pages.js
+++ b/resources/js/Pages/pages.js
@@ -427,7 +427,10 @@ const Page = () => {
           createInertiaApp({
             resolve: name => {
               const page = require(\`./Pages/\${name}\`).default
-              page.layout = page.layout || Layout
+                const DefaultLayout = (page: React.ReactNode) => (
+                      <Layout children={page} />
+                );
+              page.layout = page.layout || DefaultLayout
               return page
             },
             // ...


### PR DESCRIPTION
If the current example is used as is, only the Layout component is rendered without the page component hence the page needs to be passed as the Layout child just as in persistent layouts.