### PR TITLE
Fix SSR example for Vue

### DIFF
--- a/resources/js/Pages/server-side-rendering.jsx
+++ b/resources/js/Pages/server-side-rendering.jsx
@@ -122,10 +122,10 @@ export default function () {
                     const pages = import.meta.glob('./Pages/**/*.vue', { eager: true })
                     return pages[\`./Pages/\${name}.vue\`]
                   },
-                  setup({ app, props, plugin }) {
+                  setup({ App, props, plugin }) {
                     Vue.use(plugin)
                     return new Vue({
-                      render: h => h(app, props),
+                      render: h => h(App, props),
                     })
                   },
                 }),
@@ -149,9 +149,9 @@ export default function () {
                     const pages = import.meta.glob('./Pages/**/*.vue', { eager: true })
                     return pages[\`./Pages/\${name}.vue\`]
                   },
-                  setup({ app, props, plugin }) {
+                  setup({ App, props, plugin }) {
                     return createSSRApp({
-                      render: () => h(app, props),
+                      render: () => h(App, props),
                     }).use(plugin)
                   },
                 }),


### PR DESCRIPTION
The parameter `app` does not exist, therefore SSR will output `[Vue warn]: Invalid vnode type when creating vnode: undefined.` when visiting a page.  I've updated the example with the correct parameter.