### PR TITLE
change install to require

### DIFF
--- a/resources/js/Pages/server-side-rendering.jsx
+++ b/resources/js/Pages/server-side-rendering.jsx
@@ -85,7 +85,7 @@ export default function () {
       <CodeBlock
         language="bash"
         children={dedent`
-          composer install inertiajs/inertia-laravel
+          composer require inertiajs/inertia-laravel
         `}
       />
       <H2>Add server entry-point</H2>


### PR DESCRIPTION
Will patch docs page, fix composer syntax `install` to `require`
`composer install inertiajs/inertia-laravel`
To
`composer require inertiajs/inertia-laravel`