### PR TITLE
Update file-uploads React example

### DIFF
--- a/resources/js/Pages/file-uploads.jsx
+++ b/resources/js/Pages/file-uploads.jsx
@@ -171,7 +171,7 @@ export default function () {
               return (
                 <form onSubmit={submit}>
                   <input type="text" value={data.name} onChange={e => setData('name', e.target.value)} />
-                  <input type="file" value={data.avatar} onChange={e => setData('avatar', e.target.files[0])} />
+                  <input type="file" onChange={e => setData('avatar', e.target.files[0])} />
                   {progress && (
                     <progress value={progress.percentage} max="100">
                       {progress.percentage}%


### PR DESCRIPTION
The file upload example in React throws the error `Uncaught DOMException: Failed to set the 'value' property on 'HTMLInputElement'`.
The `value={data.avatar}` has to be removed like in the other examples.