### PR TITLE
Fix Laravel Forge SSR deploy command

### DIFF
--- a/resources/js/Pages/server-side-rendering.jsx
+++ b/resources/js/Pages/server-side-rendering.jsx
@@ -392,7 +392,7 @@ export default function () {
       </P>
       <P>
         Next, whenever you deploy your application, you'll need to automatically restart the SSR server by calling the{' '}
-        <Code>php artisan inertia:start-ssr</Code> command. This will stop the existing SSR server, forcing a new one to
+        <Code>php artisan inertia:stop-ssr</Code> command. This will stop the existing SSR server, forcing a new one to
         start.
       </P>
       <H2>Heroku</H2>


### PR DESCRIPTION
When deploying, the `php artisan inertia:stop-ssr` command should be used, so that the process run by the deamon stops and the daemon can spawn a new one.

If we would run the `php artisan inertia:start-ssr` command, as the doc currently states, the SSR node server process would be run from the deploy command.