### PR TITLE
Gonertia: new Go adapter for Inertia.js

### DIFF
--- a/resources/js/Pages/community-adapters.jsx
+++ b/resources/js/Pages/community-adapters.jsx
@@ -38,7 +38,10 @@ export default function () {
           <A href="https://pypi.org/project/inertia-django/">Django</A>
         </Li>
         <Li>
-          <A href="https://github.com/petaki/inertia-go">Go</A>
+          <A href="https://github.com/petaki/inertia-go">Go (inertia-go)</A>
+        </Li>
+        <Li>
+          <A href="https://github.com/romsar/gonertia">Go (gonertia)</A>
         </Li>
         <Li>
           <A href="https://github.com/girardinsamuel/masonite-inertia/">Masonite</A>


### PR DESCRIPTION
Hey!

I'm developing https://github.com/romsar/gonertia that is adapter of Inertia.js for Go.

petaki/inertia-go is a good package, but, unfortunately it doesn't cover some cases (closure and lazy props, 302->303, redirect back if empty response/vary header).

At the moment, my package has all these features and soon I'll add helpers for validation errors, SSR and other features that official Laravel adapter includes.