### PR TITLE
fix filename from 'app.js' to 'ssr.js'

### DIFF
--- a/resources/js/Pages/server-side-rendering.jsx
+++ b/resources/js/Pages/server-side-rendering.jsx
@@ -272,7 +272,7 @@ export default function () {
       </Vue2>
       <Vue3>
         <P>
-          To enable client-side hydration in a Vue 3 app, update your <Code>app.js</Code> file to use{' '}
+          To enable client-side hydration in a Vue 3 app, update your <Code>ssr.js</Code> file to use{' '}
           <Code>createSSRApp</Code> instead of <Code>createApp</Code>:
         </P>
       </Vue3>


### PR DESCRIPTION
There is a filename error when talking about the Client side hydration. It should be 'ssr.js' because it's the server-side rendering section.