### PR TITLE
Add link to code-splitting

### DIFF
--- a/resources/js/Components/Nav.jsx
+++ b/resources/js/Components/Nav.jsx
@@ -202,6 +202,11 @@ const Nav = ({ className }) => {
             Server-side rendering
           </Link>
         </li>
+        <li className="md:pr-3">
+          <Link href="/code-splitting" className={linkClass('/code-splitting')}>
+            Code splitting
+          </Link>
+        </li>
       </ul>
     </nav>
   )


### PR DESCRIPTION
This adds a link to https://inertiajs.com/code-splitting in the sidebar, as it's currently only mentioned on the [client-side setup](https://inertiajs.com/client-side-setup) page