### PR TITLE
Update link to Laravel Dusk

### DIFF
--- a/resources/js/Pages/testing.jsx
+++ b/resources/js/Pages/testing.jsx
@@ -21,7 +21,7 @@ export default function () {
       <H2>End-to-end tests</H2>
       <P>
         One popular approach to testing your JavaScript page components is to use an end-to-end testing tool like{' '}
-        <A href="https://www.cypress.io/">Cypress</A> or <A href="https://laravel.com/docs/8.x/dusk">Laravel Dusk</A>.
+        <A href="https://www.cypress.io/">Cypress</A> or <A href="https://laravel.com/docs/dusk">Laravel Dusk</A>.
         These are browser automation tools that allow you to run real simulations of your app in the browser. These
         tests are known to be slower; however, since they test your application at the same layer as your end users,
         they can provide a lot of confidence that your app is working correctly. And, since these tests are run in the


### PR DESCRIPTION
I updated the link to Laravel Dusk on the testing page to always point to the docs for the newest version of Laravel.