### PR TITLE
Update community-adapters.jsx

### DIFF
--- a/resources/js/Pages/community-adapters.jsx
+++ b/resources/js/Pages/community-adapters.jsx
@@ -47,9 +47,6 @@ export default function () {
           <A href="https://github.com/tbreuss/inertia-mithril">Mithril.js</A>
         </Li>
         <Li>
-          <A href="https://github.com/jordankaerim/inertia-node">Node.js</A>
-        </Li>
-        <Li>
           <A href="https://github.com/inertiajs/inertia-phoenix">Phoenix</A>
         </Li>
         <Li>


### PR DESCRIPTION
Node.js adapter links is going to a 404. Also the edit adapters link is wrong. So updated both