### PR TITLE
Update the response size limit of Firefox in responses.jsx

### DIFF
--- a/resources/js/Pages/responses.jsx
+++ b/resources/js/Pages/responses.jsx
@@ -122,7 +122,7 @@ export default function () {
       </P>
       <P>
         For example, <A href="https://developer.mozilla.org/en-US/docs/Web/API/History/pushState">Firefox</A> has a size
-        limit of 640k characters and throws a <Code>NS_ERROR_ILLEGAL_VALUE</Code> error if you exceed this limit.
+        limit of 16 MiB and throws a <Code>NS_ERROR_ILLEGAL_VALUE</Code> error if you exceed this limit.
         Typically, this is much more data than you'll ever practically need when building applications.
       </P>
     </>


### PR DESCRIPTION
The response size limit of Firefox is not 640 KB anymore. It is **16 MiB**:
https://developer.mozilla.org/en-US/docs/Web/API/History/pushState#parameters

![image](https://github.com/inertiajs/inertiajs.com/assets/62181905/f0f1aeb1-6760-465f-8e22-849831a7767f)
