### PR TITLE
Update svelte code snippet for manaually saving state in remembering-state.jsx

### DIFF
--- a/resources/js/Pages/remembering-state.jsx
+++ b/resources/js/Pages/remembering-state.jsx
@@ -366,7 +366,7 @@ export default function () {
             name: 'Svelte',
             language: 'js',
             code: dedent`
-              import { router } from '@inertiajs/svelte'
+              import { router } from '@inertiajs/core'
 
               // Save local component state to history state...
               router.remember(data, 'my-key')


### PR DESCRIPTION
Update the svelte code snippet for manually saving state. `@inertiajs/svelte` does not export `router` and `@inertiajs/core` does, so I've updated the snippet to import from `@inertiajs/core`.

Perhaps `@inertia/svelte` should expose `route`, however, this change is focused on keeping the docs accurate.

Here's what I get if I try to use `import { router } from "@inertiajs/svelete";`:

<img width="724" alt="image" src="https://github.com/inertiajs/inertiajs.com/assets/3317231/779250bb-3653-4162-a0a5-ce3e3582edb5">
