### PR TITLE
Update error handling example to skip non Inertia requests

### DIFF
--- a/resources/js/Pages/error-handling.jsx
+++ b/resources/js/Pages/error-handling.jsx
@@ -63,6 +63,12 @@ export default function () {
               {
                   $response = parent::render($request, $e);
 
+                  $isInertia = $request->header('X-Inertia') === 'true';
+
+                  if (!$isInertia) {
+                    return $response;
+                  }
+
                   if (! app()->environment(['local', 'testing']) && in_array($response->status(), [500, 503, 404, 403])) {
                       return Inertia::render('Error', ['status' => $response->status()])
                           ->toResponse($request)


### PR DESCRIPTION
Update error handling example to only render an Inertia error view if the request is expecting an Inertia response, allowing for regular XHR requests.