### PR TITLE
Fix error handling snippet

### DIFF
--- a/resources/js/Pages/error-handling.jsx
+++ b/resources/js/Pages/error-handling.jsx
@@ -50,11 +50,12 @@ export default function () {
             name: 'Laravel',
             language: 'php',
             code: dedent`
+              use Illuminate\\Http\\Request;
+              use Illuminate\\Http\\Response;
               use Inertia\\Inertia;
-              use Symfony\\Component\\HttpFoundation\\Response;
 
               ->withExceptions(function (Exceptions $exceptions) {
-                  $exceptions->respond(function (Response $response) {
+                  $exceptions->respond(function (Response $response, Throwable $exception, Request $request) {
                       if (! app()->environment(['local', 'testing']) && in_array($response->status(), [500, 503, 404, 403])) {
                           return Inertia::render('Error', ['status' => $response->status()])
                               ->toResponse($request)


### PR DESCRIPTION
This PR fixes some issues with the error-handling code snippet for Laravel 11.

The main issue is that the closure did not accept the `$request` variable, which is used later.

Additionally, the `Symfony\Component\HttpFoundation\Response` type does not define the `status` method, so IDEs/static analysis think it's missing. I checked the actual class the closure receives and got `Illuminate\Http\Request`, where the `status` method is defined.

The only thing I'm not sure of is whether there is ever a situation where a different response class may be received in the closure, which won't pass the type check and may not contain the `status` method.