### PR TITLE
Update Error Handling docs

### DIFF
--- a/resources/js/Pages/error-handling.jsx
+++ b/resources/js/Pages/error-handling.jsx
@@ -51,16 +51,16 @@ export default function () {
             language: 'php',
             code: dedent`
               use Illuminate\\Http\\Request;
-              use Illuminate\\Http\\Response;
+              use Symfony\Component\HttpFoundation\Response;
               use Inertia\\Inertia;
 
               ->withExceptions(function (Exceptions $exceptions) {
                   $exceptions->respond(function (Response $response, Throwable $exception, Request $request) {
-                      if (! app()->environment(['local', 'testing']) && in_array($response->status(), [500, 503, 404, 403])) {
-                          return Inertia::render('Error', ['status' => $response->status()])
+                      if (! app()->environment(['local', 'testing']) && in_array($response->getStatusCode(), [500, 503, 404, 403])) {
+                          return Inertia::render('Error', ['status' => $response->getStatusCode()])
                               ->toResponse($request)
-                              ->setStatusCode($response->status());
-                      } elseif ($response->status() === 419) {
+                              ->setStatusCode($response->getStatusCode());
+                      } elseif ($response->getStatusCode() === 419) {
                           return back()->with([
                               'message' => 'The page expired, please try again.',
                           ]);

--- a/resources/js/Pages/error-handling.jsx
+++ b/resources/js/Pages/error-handling.jsx
@@ -51,7 +51,7 @@ export default function () {
             language: 'php',
             code: dedent`
               use Illuminate\\Http\\Request;
-              use Symfony\Component\HttpFoundation\Response;
+              use Symfony\\Component\\HttpFoundation\\Response;
               use Inertia\\Inertia;
 
               ->withExceptions(function (Exceptions $exceptions) {


### PR DESCRIPTION
When user try to input the wrong password, or bad input that return errors. This is what will happened.
```bash
{closure}(): Argument #1 ($response) must be of type Illuminate\Http\Response, Illuminate\Http\RedirectResponse given
```

Of course in production, it will be 500.

This PR will fix that.

