### PR TITLE
fix(clientSetup) : fix react installation and initialization code.

### DIFF
--- a/resources/js/Pages/client-side-setup.jsx
+++ b/resources/js/Pages/client-side-setup.jsx
@@ -49,7 +49,7 @@ export default function () {
             name: 'React',
             language: 'bash',
             code: dedent`
-              npm install @inertiajs/react
+              npm install @inertiajs/react react react-dom
             `,
           },
           {
@@ -116,6 +116,7 @@ export default function () {
             code: dedent`
               import { createInertiaApp } from '@inertiajs/react'
               import { createRoot } from 'react-dom/client'
+              import React from 'react';
 
               createInertiaApp({
                 resolve: name => {


### PR DESCRIPTION
Help for beginners to start using inertia-js with react.
- Adding the `react` and `react-dom` installation to make it clear that people need to install it.
- Adding import from `react` in initialization app.jsx to make it run.