### PR TITLE
chore(adapters): add real AdonisJS adapter

### DIFF
--- a/resources/js/Pages/community-adapters.jsx
+++ b/resources/js/Pages/community-adapters.jsx
@@ -17,7 +17,7 @@ export default function () {
           <A href="https://github.com/inertiajs/inertia-rails">Rails</A>
         </Li>
         <Li>
-          <A href="https://github.com/eidellev/inertiajs-adonisjs">AdonisJs</A>
+          <A href="https://docs.adonisjs.com/guides/inertia">AdonisJS</A>
         </Li>
         <Li>
           <A href="https://github.com/ishanvyas22/cakephp-inertiajs">CakePHP</A>


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds the built-in adapters from the AdonisJS core team instead of a third-party one.

The built-in adapter is deeply integrated with AdonisJS, it works with version 6, it has backed-in support for SSR without any changes and is maintained by the core team of the framework.