### PR TITLE
Fix CSRF protection example of React

### DIFF
--- a/resources/js/Pages/csrf-protection.jsx
+++ b/resources/js/Pages/csrf-protection.jsx
@@ -65,12 +65,14 @@ export default function () {
             name: 'React',
             language: 'js',
             code: dedent`
-              import { router } from '@inertiajs/react'
+              import { router, usePage } from '@inertiajs/react'
+
+              const page = usePage()
 
               router.post('/users', {
-                name: this.name,
-                email: this.email,
-                _token: this.$page.props.csrf_token,
+                name: 'John Doe',
+                email: 'john.doe@example.com',
+                _token: page.props.csrf_token,
               })
             `,
           },

--- a/resources/js/Pages/csrf-protection.jsx
+++ b/resources/js/Pages/csrf-protection.jsx
@@ -42,9 +42,9 @@ export default function () {
               import { router } from '@inertiajs/vue2'
 
               router.post('/users', {
-                name: this.name,
-                email: this.email,
                 _token: this.$page.props.csrf_token,
+                name: 'John Doe',
+                email: 'john.doe@example.com',
               })
             `,
           },
@@ -52,12 +52,14 @@ export default function () {
             name: 'Vue 3',
             language: 'js',
             code: dedent`
-              import { router } from '@inertiajs/vue3'
+              import { router, usePage } from '@inertiajs/vue3'
+
+              const page = usePage()
 
               router.post('/users', {
-                name: this.name,
-                email: this.email,
-                _token: this.$page.props.csrf_token,
+                _token: page.props.csrf_token,
+                name: 'John Doe',
+                email: 'john.doe@example.com',
               })
             `,
           },
@@ -67,12 +69,12 @@ export default function () {
             code: dedent`
               import { router, usePage } from '@inertiajs/react'
 
-              const page = usePage()
+              const props = usePage().props
 
               router.post('/users', {
+                _token: props.csrf_token,
                 name: 'John Doe',
                 email: 'john.doe@example.com',
-                _token: page.props.csrf_token,
               })
             `,
           },
@@ -80,12 +82,12 @@ export default function () {
             name: 'Svelte',
             language: 'js',
             code: dedent`
-              import { router } from '@inertiajs/svelte'
+              import { page, router } from '@inertiajs/svelte'
 
               router.post('/users', {
-                name: this.name,
-                email: this.email,
-                _token: this.$page.props.csrf_token,
+                _token: $page.props.csrf_token,
+                name: 'John Doe',
+                email: 'john.doe@example.com',
               })
             `,
           },


### PR DESCRIPTION
While using the Vue adapters, page props are available through `$page.props.<property>` but in React we have to use either `usePage()` hook or `Component props` 🙂