### PR TITLE
change content tag in shared-data.jsx

### DIFF
--- a/resources/js/Pages/shared-data.jsx
+++ b/resources/js/Pages/shared-data.jsx
@@ -101,9 +101,9 @@ export default function () {
                   <header>
                     You are logged in as: {{ user.name }}
                   </header>
-                  <content>
+                  <article>
                     <slot />
-                  </content>
+                  </article>
                 </main>
               </template>
 
@@ -136,9 +136,9 @@ export default function () {
                   <header>
                     You are logged in as: {{ user.name }}
                   </header>
-                  <content>
+                  <article>
                     <slot />
-                  </content>
+                  </article>
                 </main>
               </template>
             `,
@@ -157,9 +157,9 @@ export default function () {
                     <header>
                       You are logged in as: {auth.user.name}
                     </header>
-                    <content>
+                    <article>
                       {children}
-                    </content>
+                    </article>
                   </main>
                 )
               }
@@ -177,9 +177,9 @@ export default function () {
                 <header>
                   You are logged in as: {$page.props.auth.user.name}
                 </header>
-                <content>
+                <article>
                   <slot />
-                </content>
+                </article>
               </main>
             `,
           },
@@ -226,12 +226,12 @@ export default function () {
               <template>
                 <main>
                   <header></header>
-                  <content>
+                  <article>
                     <div v-if="$page.props.flash.message" class="alert">
                       {{ $page.props.flash.message }}
                     </div>
                     <slot />
-                  </content>
+                  </article>
                   <footer></footer>
                 </main>
               </template>
@@ -244,12 +244,12 @@ export default function () {
               <template>
                 <main>
                   <header></header>
-                  <content>
+                  <article>
                     <div v-if="$page.props.flash.message" class="alert">
                       {{ $page.props.flash.message }}
                     </div>
                     <slot />
-                  </content>
+                  </article>
                   <footer></footer>
                 </main>
               </template>
@@ -267,12 +267,12 @@ export default function () {
                 return (
                   <main>
                     <header></header>
-                    <content>
+                    <article>
                       {flash.message && (
                         <div class="alert">{flash.message}</div>
                       )}
                       {children}
-                    </content>
+                    </article>
                     <footer></footer>
                   </main>
                 )
@@ -289,12 +289,12 @@ export default function () {
 
               <main>
                 <header></header>
-                <content>
+                <article>
                   {#if $page.props.flash.message}
                     <div class="alert">{$page.props.flash.message}</div>
                   {/if}
                   <slot />
-                </content>
+                </article>
                 <footer></footer>
               </main>
             `,


### PR DESCRIPTION
Change `<content>` to `<article>` 

As per https://developer.mozilla.org/en-US/docs/Web/HTML/Element#obsolete_and_deprecated_elements

> An obsolete part of the Web Components suite of technologies—was used inside of Shadow DOM as an insertion point, and wasn't meant to be used in ordinary HTML. It has now been replaced by the `<slot>` element, which creates a point in the DOM at which a shadow DOM can be inserted. Consider using `<slot>` instead.


I think the intention here is not to be an insertion point, so I changed to `<article>`