### PR TITLE
Add ASP.NET Core Community Adapter

### DIFF
--- a/resources/js/Pages/community-adapters.jsx
+++ b/resources/js/Pages/community-adapters.jsx
@@ -73,6 +73,9 @@ export default function () {
         <Li>
           <A href="https://github.com/tobimori/kirby-inertia">Kirby CMS</A>
         </Li>
+        <Li>
+          <A href="https://github.com/kapi2289/InertiaCore">ASP.NET Core</A>
+        </Li>
       </Ul>
       <P>
         If you have an adapter you'd like listed here, please send a{' '}


### PR DESCRIPTION
This is a great community adapter we've been using for ASP.NET Core. I helped contribute the Vite helper to the project to aid with DX. I also plan to help contribute v2 features to InertiaCore when they are released in the first party adapters.

https://github.com/kapi2289/InertiaCore