### PR TITLE
Docs: remove Ignition reference

### DIFF
--- a/resources/js/Pages/error-handling.jsx
+++ b/resources/js/Pages/error-handling.jsx
@@ -16,8 +16,8 @@ export default function () {
       <H2>Development</H2>
       <P>
         One of the advantages to working with a robust server-side framework is the built-in exception handling you get
-        for free. For example, Laravel ships with <A href="https://github.com/facade/ignition">Ignition</A>, a beautiful
-        error reporting tool which displays a nicely formatted stack trace in local development.
+        for free. For example, Laravel ships with a beautiful error reporting tool which displays a nicely formatted
+        stack trace in local development.
       </P>
       <P>
         The challenge is, if you're making an XHR request (which Inertia does) and you hit a server-side error, you're


### PR DESCRIPTION
Laravel doesn't ship with Ignition anymore, so I removed the reference.