### PR TITLE
Updated file-uploads.jsx to remove value attribute from input file type

### DIFF
--- a/resources/js/Pages/file-uploads.jsx
+++ b/resources/js/Pages/file-uploads.jsx
@@ -171,7 +171,7 @@ export default function () {
               return (
                 <form onSubmit={submit}>
                   <input type="text" value={data.name} onChange={e => setData('name', e.target.value)} />
-                  <input type="file" value={data.avatar} onChange={e => setData('avatar', e.target.files[0])} />
+                  <input type="file" onChange={e => setData('avatar', e.target.files[0])} />
                   {progress && (
                     <progress value={progress.percentage} max="100">
                       {progress.percentage}%


### PR DESCRIPTION
Setting value attribute on input type file, Gives an error in HTML. Best to leave it empty.
<img width="415" alt="image" src="https://github.com/user-attachments/assets/fb959161-d0fa-4066-ba94-995d81e997f8">
