### PR TITLE
chore: upgrade DocSearch version and use v2 index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "inertia-website",
+    "name": "inertiajs.com",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "dependencies": {
-                "@docsearch/react": "^3.3.0",
+                "@docsearch/react": "^3.6.2",
                 "@inertiajs/react": "^1.0.0",
                 "@vitejs/plugin-react": "^3.0.1",
                 "autoprefixer": "^10.4.13",
@@ -23,19 +23,31 @@
             }
         },
         "node_modules/@algolia/autocomplete-core": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.4.tgz",
-            "integrity": "sha512-daoLpQ3ps/VTMRZDEBfU8ixXd+amZcNJ4QSP3IERGyzqnL5Ch8uSRFt/4G8pUvW9c3o6GA4vtVv4I4lmnkdXyg==",
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+            "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
             "dependencies": {
-                "@algolia/autocomplete-shared": "1.7.4"
+                "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
+                "@algolia/autocomplete-shared": "1.9.3"
+            }
+        },
+        "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+            "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+            "dependencies": {
+                "@algolia/autocomplete-shared": "1.9.3"
+            },
+            "peerDependencies": {
+                "search-insights": ">= 1 < 3"
             }
         },
         "node_modules/@algolia/autocomplete-preset-algolia": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.4.tgz",
-            "integrity": "sha512-s37hrvLEIfcmKY8VU9LsAXgm2yfmkdHT3DnA3SgHaY93yjZ2qL57wzb5QweVkYuEBZkT2PIREvRoLXC2sxTbpQ==",
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+            "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
             "dependencies": {
-                "@algolia/autocomplete-shared": "1.7.4"
+                "@algolia/autocomplete-shared": "1.9.3"
             },
             "peerDependencies": {
                 "@algolia/client-search": ">= 4.9.1 < 6",
@@ -43,123 +55,252 @@
             }
         },
         "node_modules/@algolia/autocomplete-shared": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.4.tgz",
-            "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+            "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+            "peerDependencies": {
+                "@algolia/client-search": ">= 4.9.1 < 6",
+                "algoliasearch": ">= 4.9.1 < 6"
+            }
         },
         "node_modules/@algolia/cache-browser-local-storage": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.3.tgz",
-            "integrity": "sha512-hWH1yCxgG3+R/xZIscmUrWAIBnmBFHH5j30fY/+aPkEZWt90wYILfAHIOZ1/Wxhho5SkPfwFmT7ooX2d9JeQBw==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.24.0.tgz",
+            "integrity": "sha512-t63W9BnoXVrGy9iYHBgObNXqYXM3tYXCjDSHeNwnsc324r4o5UiVKUiAB4THQ5z9U5hTj6qUvwg/Ez43ZD85ww==",
             "dependencies": {
-                "@algolia/cache-common": "4.14.3"
+                "@algolia/cache-common": "4.24.0"
             }
         },
         "node_modules/@algolia/cache-common": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.3.tgz",
-            "integrity": "sha512-oZJofOoD9FQOwiGTzyRnmzvh3ZP8WVTNPBLH5xU5JNF7drDbRT0ocVT0h/xB2rPHYzOeXRrLaQQBwRT/CKom0Q=="
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.24.0.tgz",
+            "integrity": "sha512-emi+v+DmVLpMGhp0V9q9h5CdkURsNmFC+cOS6uK9ndeJm9J4TiqSvPYVu+THUP8P/S08rxf5x2P+p3CfID0Y4g=="
         },
         "node_modules/@algolia/cache-in-memory": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.3.tgz",
-            "integrity": "sha512-ES0hHQnzWjeioLQf5Nq+x1AWdZJ50znNPSH3puB/Y4Xsg4Av1bvLmTJe7SY2uqONaeMTvL0OaVcoVtQgJVw0vg==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.24.0.tgz",
+            "integrity": "sha512-gDrt2so19jW26jY3/MkFg5mEypFIPbPoXsQGQWAi6TrCPsNOSEYepBMPlucqWigsmEy/prp5ug2jy/N3PVG/8w==",
             "dependencies": {
-                "@algolia/cache-common": "4.14.3"
+                "@algolia/cache-common": "4.24.0"
             }
         },
         "node_modules/@algolia/client-account": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.3.tgz",
-            "integrity": "sha512-PBcPb0+f5Xbh5UfLZNx2Ow589OdP8WYjB4CnvupfYBrl9JyC1sdH4jcq/ri8osO/mCZYjZrQsKAPIqW/gQmizQ==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
+            "integrity": "sha512-adcvyJ3KjPZFDybxlqnf+5KgxJtBjwTPTeyG2aOyoJvx0Y8dUQAEOEVOJ/GBxX0WWNbmaSrhDURMhc+QeevDsA==",
             "dependencies": {
-                "@algolia/client-common": "4.14.3",
-                "@algolia/client-search": "4.14.3",
-                "@algolia/transporter": "4.14.3"
+                "@algolia/client-common": "4.24.0",
+                "@algolia/client-search": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@algolia/client-account/node_modules/@algolia/client-common": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+            "dependencies": {
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@algolia/client-account/node_modules/@algolia/client-search": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+            "dependencies": {
+                "@algolia/client-common": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
             }
         },
         "node_modules/@algolia/client-analytics": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.3.tgz",
-            "integrity": "sha512-eAwQq0Hb/aauv9NhCH5Dp3Nm29oFx28sayFN2fdOWemwSeJHIl7TmcsxVlRsO50fsD8CtPcDhtGeD3AIFLNvqw==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
+            "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
             "dependencies": {
-                "@algolia/client-common": "4.14.3",
-                "@algolia/client-search": "4.14.3",
-                "@algolia/requester-common": "4.14.3",
-                "@algolia/transporter": "4.14.3"
+                "@algolia/client-common": "4.24.0",
+                "@algolia/client-search": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@algolia/client-analytics/node_modules/@algolia/client-common": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+            "dependencies": {
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@algolia/client-analytics/node_modules/@algolia/client-search": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+            "dependencies": {
+                "@algolia/client-common": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
             }
         },
         "node_modules/@algolia/client-common": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.3.tgz",
-            "integrity": "sha512-jkPPDZdi63IK64Yg4WccdCsAP4pHxSkr4usplkUZM5C1l1oEpZXsy2c579LQ0rvwCs5JFmwfNG4ahOszidfWPw==",
-            "dependencies": {
-                "@algolia/requester-common": "4.14.3",
-                "@algolia/transporter": "4.14.3"
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.8.0.tgz",
+            "integrity": "sha512-KSnRo4q8Ne9McDKxb1i4mDFNiRt8vT9SzJDitax/2qYYWyhPP0pvQ6jl7f00zovfsBg8lVabDdDAhDgY5PIvvA==",
+            "peer": true,
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-personalization": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.3.tgz",
-            "integrity": "sha512-UCX1MtkVNgaOL9f0e22x6tC9e2H3unZQlSUdnVaSKpZ+hdSChXGaRjp2UIT7pxmPqNCyv51F597KEX5WT60jNg==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
+            "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
             "dependencies": {
-                "@algolia/client-common": "4.14.3",
-                "@algolia/requester-common": "4.14.3",
-                "@algolia/transporter": "4.14.3"
+                "@algolia/client-common": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@algolia/client-personalization/node_modules/@algolia/client-common": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+            "dependencies": {
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
             }
         },
         "node_modules/@algolia/client-search": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.3.tgz",
-            "integrity": "sha512-I2U7xBx5OPFdPLA8AXKUPPxGY3HDxZ4r7+mlZ8ZpLbI8/ri6fnu6B4z3wcL7sgHhDYMwnAE8Xr0AB0h3Hnkp4A==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.8.0.tgz",
+            "integrity": "sha512-meIT0dIjafbDhZGfXMZ02pKbvNjItH8yZORTLpA2wYWBpRWqGzNDXedD/ayFh/tm5+L0IGlSWIgfhofKfDRsFQ==",
+            "peer": true,
             "dependencies": {
-                "@algolia/client-common": "4.14.3",
-                "@algolia/requester-common": "4.14.3",
-                "@algolia/transporter": "4.14.3"
+                "@algolia/client-common": "5.8.0",
+                "@algolia/requester-browser-xhr": "5.8.0",
+                "@algolia/requester-fetch": "5.8.0",
+                "@algolia/requester-node-http": "5.8.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/logger-common": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.3.tgz",
-            "integrity": "sha512-kUEAZaBt/J3RjYi8MEBT2QEexJR2kAE2mtLmezsmqMQZTV502TkHCxYzTwY2dE7OKcUTxi4OFlMuS4GId9CWPw=="
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.24.0.tgz",
+            "integrity": "sha512-LLUNjkahj9KtKYrQhFKCzMx0BY3RnNP4FEtO+sBybCjJ73E8jNdaKJ/Dd8A/VA4imVHP5tADZ8pn5B8Ga/wTMA=="
         },
         "node_modules/@algolia/logger-console": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.3.tgz",
-            "integrity": "sha512-ZWqAlUITktiMN2EiFpQIFCJS10N96A++yrexqC2Z+3hgF/JcKrOxOdT4nSCQoEPvU4Ki9QKbpzbebRDemZt/hw==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.24.0.tgz",
+            "integrity": "sha512-X4C8IoHgHfiUROfoRCV+lzSy+LHMgkoEEU1BbKcsfnV0i0S20zyy0NLww9dwVHUWNfPPxdMU+/wKmLGYf96yTg==",
             "dependencies": {
-                "@algolia/logger-common": "4.14.3"
+                "@algolia/logger-common": "4.24.0"
+            }
+        },
+        "node_modules/@algolia/recommend": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
+            "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
+            "dependencies": {
+                "@algolia/cache-browser-local-storage": "4.24.0",
+                "@algolia/cache-common": "4.24.0",
+                "@algolia/cache-in-memory": "4.24.0",
+                "@algolia/client-common": "4.24.0",
+                "@algolia/client-search": "4.24.0",
+                "@algolia/logger-common": "4.24.0",
+                "@algolia/logger-console": "4.24.0",
+                "@algolia/requester-browser-xhr": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/requester-node-http": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@algolia/recommend/node_modules/@algolia/client-common": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+            "dependencies": {
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@algolia/recommend/node_modules/@algolia/client-search": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+            "dependencies": {
+                "@algolia/client-common": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/@algolia/recommend/node_modules/@algolia/requester-browser-xhr": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+            "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
+            "dependencies": {
+                "@algolia/requester-common": "4.24.0"
+            }
+        },
+        "node_modules/@algolia/recommend/node_modules/@algolia/requester-node-http": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+            "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+            "dependencies": {
+                "@algolia/requester-common": "4.24.0"
             }
         },
         "node_modules/@algolia/requester-browser-xhr": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.3.tgz",
-            "integrity": "sha512-AZeg2T08WLUPvDncl2XLX2O67W5wIO8MNaT7z5ii5LgBTuk/rU4CikTjCe2xsUleIZeFl++QrPAi4Bdxws6r/Q==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.8.0.tgz",
+            "integrity": "sha512-Gi33fRclktW+zJSmT2Gkntiu+BNkh+50NhfYLALHV4yZ3jH73PYbPNURFa1/NxaUpzPvXrld0BrsHDTS1QBBTQ==",
+            "peer": true,
             "dependencies": {
-                "@algolia/requester-common": "4.14.3"
+                "@algolia/client-common": "5.8.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-common": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.3.tgz",
-            "integrity": "sha512-RrRzqNyKFDP7IkTuV3XvYGF9cDPn9h6qEDl595lXva3YUk9YSS8+MGZnnkOMHvjkrSCKfoLeLbm/T4tmoIeclw=="
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.24.0.tgz",
+            "integrity": "sha512-k3CXJ2OVnvgE3HMwcojpvY6d9kgKMPRxs/kVohrwF5WMr2fnqojnycZkxPoEg+bXm8fi5BBfFmOqgYztRtHsQA=="
+        },
+        "node_modules/@algolia/requester-fetch": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.8.0.tgz",
+            "integrity": "sha512-ve7ynA+O0KDrA2AAQ62GKQB+HjdHd0gX3tsXwlcfFOd7CYb2+xc+eOrVXV9mSlGS6Ssrd8V0AQ6BMId5KyypwQ==",
+            "peer": true,
+            "dependencies": {
+                "@algolia/client-common": "5.8.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
         },
         "node_modules/@algolia/requester-node-http": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.3.tgz",
-            "integrity": "sha512-O5wnPxtDRPuW2U0EaOz9rMMWdlhwP0J0eSL1Z7TtXF8xnUeeUyNJrdhV5uy2CAp6RbhM1VuC3sOJcIR6Av+vbA==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.8.0.tgz",
+            "integrity": "sha512-2sv9af4Pg58soGj3F0czK8xT2RVh/cX7UmMMjTQwkp7LK7SMW9OoDmg9FSvU5ge6KH0wd1TrxT/4XgRHc1P/NA==",
+            "peer": true,
             "dependencies": {
-                "@algolia/requester-common": "4.14.3"
+                "@algolia/client-common": "5.8.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/transporter": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.3.tgz",
-            "integrity": "sha512-2qlKlKsnGJ008exFRb5RTeTOqhLZj0bkMCMVskxoqWejs2Q2QtWmsiH98hDfpw0fmnyhzHEt0Z7lqxBYp8bW2w==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.24.0.tgz",
+            "integrity": "sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==",
             "dependencies": {
-                "@algolia/cache-common": "4.14.3",
-                "@algolia/logger-common": "4.14.3",
-                "@algolia/requester-common": "4.14.3"
+                "@algolia/cache-common": "4.24.0",
+                "@algolia/logger-common": "4.24.0",
+                "@algolia/requester-common": "4.24.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -492,24 +633,25 @@
             }
         },
         "node_modules/@docsearch/css": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.2.tgz",
-            "integrity": "sha512-dctFYiwbvDZkksMlsmc7pj6W6By/EjnVXJq5TEPd05MwQe+dcdHJgaIn1c8wfsucxHpIsdrUcgSkACHCq6aIhw=="
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.2.tgz",
+            "integrity": "sha512-vKNZepO2j7MrYBTZIGXvlUOIR+v9KRf70FApRgovWrj3GTs1EITz/Xb0AOlm1xsQBp16clVZj1SY/qaOJbQtZw=="
         },
         "node_modules/@docsearch/react": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.2.tgz",
-            "integrity": "sha512-ugILab2TYKSh6IEHf6Z9xZbOovsYbsdfo60PBj+Bw+oMJ1MHJ7pBt1TTcmPki1hSgg8mysgKy2hDiVdPm7XWSQ==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.2.tgz",
+            "integrity": "sha512-rtZce46OOkVflCQH71IdbXSFK+S8iJZlUF56XBW5rIgx/eG5qoomC7Ag3anZson1bBac/JFQn7XOBfved/IMRA==",
             "dependencies": {
-                "@algolia/autocomplete-core": "1.7.4",
-                "@algolia/autocomplete-preset-algolia": "1.7.4",
-                "@docsearch/css": "3.3.2",
-                "algoliasearch": "^4.0.0"
+                "@algolia/autocomplete-core": "1.9.3",
+                "@algolia/autocomplete-preset-algolia": "1.9.3",
+                "@docsearch/css": "3.6.2",
+                "algoliasearch": "^4.19.1"
             },
             "peerDependencies": {
                 "@types/react": ">= 16.8.0 < 19.0.0",
                 "react": ">= 16.8.0 < 19.0.0",
-                "react-dom": ">= 16.8.0 < 19.0.0"
+                "react-dom": ">= 16.8.0 < 19.0.0",
+                "search-insights": ">= 1 < 3"
             },
             "peerDependenciesMeta": {
                 "@types/react": {
@@ -519,6 +661,9 @@
                     "optional": true
                 },
                 "react-dom": {
+                    "optional": true
+                },
+                "search-insights": {
                     "optional": true
                 }
             }
@@ -1003,24 +1148,60 @@
             }
         },
         "node_modules/algoliasearch": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.3.tgz",
-            "integrity": "sha512-GZTEuxzfWbP/vr7ZJfGzIl8fOsoxN916Z6FY2Egc9q2TmZ6hvq5KfAxY89pPW01oW/2HDEKA8d30f9iAH9eXYg==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
+            "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
             "dependencies": {
-                "@algolia/cache-browser-local-storage": "4.14.3",
-                "@algolia/cache-common": "4.14.3",
-                "@algolia/cache-in-memory": "4.14.3",
-                "@algolia/client-account": "4.14.3",
-                "@algolia/client-analytics": "4.14.3",
-                "@algolia/client-common": "4.14.3",
-                "@algolia/client-personalization": "4.14.3",
-                "@algolia/client-search": "4.14.3",
-                "@algolia/logger-common": "4.14.3",
-                "@algolia/logger-console": "4.14.3",
-                "@algolia/requester-browser-xhr": "4.14.3",
-                "@algolia/requester-common": "4.14.3",
-                "@algolia/requester-node-http": "4.14.3",
-                "@algolia/transporter": "4.14.3"
+                "@algolia/cache-browser-local-storage": "4.24.0",
+                "@algolia/cache-common": "4.24.0",
+                "@algolia/cache-in-memory": "4.24.0",
+                "@algolia/client-account": "4.24.0",
+                "@algolia/client-analytics": "4.24.0",
+                "@algolia/client-common": "4.24.0",
+                "@algolia/client-personalization": "4.24.0",
+                "@algolia/client-search": "4.24.0",
+                "@algolia/logger-common": "4.24.0",
+                "@algolia/logger-console": "4.24.0",
+                "@algolia/recommend": "4.24.0",
+                "@algolia/requester-browser-xhr": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/requester-node-http": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/algoliasearch/node_modules/@algolia/client-common": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+            "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+            "dependencies": {
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/algoliasearch/node_modules/@algolia/client-search": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+            "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+            "dependencies": {
+                "@algolia/client-common": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            }
+        },
+        "node_modules/algoliasearch/node_modules/@algolia/requester-browser-xhr": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+            "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
+            "dependencies": {
+                "@algolia/requester-common": "4.24.0"
+            }
+        },
+        "node_modules/algoliasearch/node_modules/@algolia/requester-node-http": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+            "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+            "dependencies": {
+                "@algolia/requester-common": "4.24.0"
             }
         },
         "node_modules/ansi-styles": {
@@ -2561,6 +2742,12 @@
                 "loose-envify": "^1.1.0"
             }
         },
+        "node_modules/search-insights": {
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.2.tgz",
+            "integrity": "sha512-zFNpOpUO+tY2D85KrxJ+aqwnIfdEGi06UH2+xEb+Bp9Mwznmauqc9djbnBibJO5mpfUPPa8st6Sx65+vbeO45g==",
+            "peer": true
+        },
         "node_modules/semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -2909,139 +3096,267 @@
     },
     "dependencies": {
         "@algolia/autocomplete-core": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.4.tgz",
-            "integrity": "sha512-daoLpQ3ps/VTMRZDEBfU8ixXd+amZcNJ4QSP3IERGyzqnL5Ch8uSRFt/4G8pUvW9c3o6GA4vtVv4I4lmnkdXyg==",
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+            "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
             "requires": {
-                "@algolia/autocomplete-shared": "1.7.4"
+                "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
+                "@algolia/autocomplete-shared": "1.9.3"
+            }
+        },
+        "@algolia/autocomplete-plugin-algolia-insights": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+            "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+            "requires": {
+                "@algolia/autocomplete-shared": "1.9.3"
             }
         },
         "@algolia/autocomplete-preset-algolia": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.4.tgz",
-            "integrity": "sha512-s37hrvLEIfcmKY8VU9LsAXgm2yfmkdHT3DnA3SgHaY93yjZ2qL57wzb5QweVkYuEBZkT2PIREvRoLXC2sxTbpQ==",
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+            "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
             "requires": {
-                "@algolia/autocomplete-shared": "1.7.4"
+                "@algolia/autocomplete-shared": "1.9.3"
             }
         },
         "@algolia/autocomplete-shared": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.4.tgz",
-            "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+            "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+            "requires": {}
         },
         "@algolia/cache-browser-local-storage": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.3.tgz",
-            "integrity": "sha512-hWH1yCxgG3+R/xZIscmUrWAIBnmBFHH5j30fY/+aPkEZWt90wYILfAHIOZ1/Wxhho5SkPfwFmT7ooX2d9JeQBw==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.24.0.tgz",
+            "integrity": "sha512-t63W9BnoXVrGy9iYHBgObNXqYXM3tYXCjDSHeNwnsc324r4o5UiVKUiAB4THQ5z9U5hTj6qUvwg/Ez43ZD85ww==",
             "requires": {
-                "@algolia/cache-common": "4.14.3"
+                "@algolia/cache-common": "4.24.0"
             }
         },
         "@algolia/cache-common": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.3.tgz",
-            "integrity": "sha512-oZJofOoD9FQOwiGTzyRnmzvh3ZP8WVTNPBLH5xU5JNF7drDbRT0ocVT0h/xB2rPHYzOeXRrLaQQBwRT/CKom0Q=="
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.24.0.tgz",
+            "integrity": "sha512-emi+v+DmVLpMGhp0V9q9h5CdkURsNmFC+cOS6uK9ndeJm9J4TiqSvPYVu+THUP8P/S08rxf5x2P+p3CfID0Y4g=="
         },
         "@algolia/cache-in-memory": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.3.tgz",
-            "integrity": "sha512-ES0hHQnzWjeioLQf5Nq+x1AWdZJ50znNPSH3puB/Y4Xsg4Av1bvLmTJe7SY2uqONaeMTvL0OaVcoVtQgJVw0vg==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.24.0.tgz",
+            "integrity": "sha512-gDrt2so19jW26jY3/MkFg5mEypFIPbPoXsQGQWAi6TrCPsNOSEYepBMPlucqWigsmEy/prp5ug2jy/N3PVG/8w==",
             "requires": {
-                "@algolia/cache-common": "4.14.3"
+                "@algolia/cache-common": "4.24.0"
             }
         },
         "@algolia/client-account": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.3.tgz",
-            "integrity": "sha512-PBcPb0+f5Xbh5UfLZNx2Ow589OdP8WYjB4CnvupfYBrl9JyC1sdH4jcq/ri8osO/mCZYjZrQsKAPIqW/gQmizQ==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
+            "integrity": "sha512-adcvyJ3KjPZFDybxlqnf+5KgxJtBjwTPTeyG2aOyoJvx0Y8dUQAEOEVOJ/GBxX0WWNbmaSrhDURMhc+QeevDsA==",
             "requires": {
-                "@algolia/client-common": "4.14.3",
-                "@algolia/client-search": "4.14.3",
-                "@algolia/transporter": "4.14.3"
+                "@algolia/client-common": "4.24.0",
+                "@algolia/client-search": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            },
+            "dependencies": {
+                "@algolia/client-common": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+                    "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+                    "requires": {
+                        "@algolia/requester-common": "4.24.0",
+                        "@algolia/transporter": "4.24.0"
+                    }
+                },
+                "@algolia/client-search": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+                    "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+                    "requires": {
+                        "@algolia/client-common": "4.24.0",
+                        "@algolia/requester-common": "4.24.0",
+                        "@algolia/transporter": "4.24.0"
+                    }
+                }
             }
         },
         "@algolia/client-analytics": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.3.tgz",
-            "integrity": "sha512-eAwQq0Hb/aauv9NhCH5Dp3Nm29oFx28sayFN2fdOWemwSeJHIl7TmcsxVlRsO50fsD8CtPcDhtGeD3AIFLNvqw==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
+            "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
             "requires": {
-                "@algolia/client-common": "4.14.3",
-                "@algolia/client-search": "4.14.3",
-                "@algolia/requester-common": "4.14.3",
-                "@algolia/transporter": "4.14.3"
+                "@algolia/client-common": "4.24.0",
+                "@algolia/client-search": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            },
+            "dependencies": {
+                "@algolia/client-common": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+                    "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+                    "requires": {
+                        "@algolia/requester-common": "4.24.0",
+                        "@algolia/transporter": "4.24.0"
+                    }
+                },
+                "@algolia/client-search": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+                    "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+                    "requires": {
+                        "@algolia/client-common": "4.24.0",
+                        "@algolia/requester-common": "4.24.0",
+                        "@algolia/transporter": "4.24.0"
+                    }
+                }
             }
         },
         "@algolia/client-common": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.3.tgz",
-            "integrity": "sha512-jkPPDZdi63IK64Yg4WccdCsAP4pHxSkr4usplkUZM5C1l1oEpZXsy2c579LQ0rvwCs5JFmwfNG4ahOszidfWPw==",
-            "requires": {
-                "@algolia/requester-common": "4.14.3",
-                "@algolia/transporter": "4.14.3"
-            }
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.8.0.tgz",
+            "integrity": "sha512-KSnRo4q8Ne9McDKxb1i4mDFNiRt8vT9SzJDitax/2qYYWyhPP0pvQ6jl7f00zovfsBg8lVabDdDAhDgY5PIvvA==",
+            "peer": true
         },
         "@algolia/client-personalization": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.3.tgz",
-            "integrity": "sha512-UCX1MtkVNgaOL9f0e22x6tC9e2H3unZQlSUdnVaSKpZ+hdSChXGaRjp2UIT7pxmPqNCyv51F597KEX5WT60jNg==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
+            "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
             "requires": {
-                "@algolia/client-common": "4.14.3",
-                "@algolia/requester-common": "4.14.3",
-                "@algolia/transporter": "4.14.3"
+                "@algolia/client-common": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            },
+            "dependencies": {
+                "@algolia/client-common": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+                    "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+                    "requires": {
+                        "@algolia/requester-common": "4.24.0",
+                        "@algolia/transporter": "4.24.0"
+                    }
+                }
             }
         },
         "@algolia/client-search": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.3.tgz",
-            "integrity": "sha512-I2U7xBx5OPFdPLA8AXKUPPxGY3HDxZ4r7+mlZ8ZpLbI8/ri6fnu6B4z3wcL7sgHhDYMwnAE8Xr0AB0h3Hnkp4A==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.8.0.tgz",
+            "integrity": "sha512-meIT0dIjafbDhZGfXMZ02pKbvNjItH8yZORTLpA2wYWBpRWqGzNDXedD/ayFh/tm5+L0IGlSWIgfhofKfDRsFQ==",
+            "peer": true,
             "requires": {
-                "@algolia/client-common": "4.14.3",
-                "@algolia/requester-common": "4.14.3",
-                "@algolia/transporter": "4.14.3"
+                "@algolia/client-common": "5.8.0",
+                "@algolia/requester-browser-xhr": "5.8.0",
+                "@algolia/requester-fetch": "5.8.0",
+                "@algolia/requester-node-http": "5.8.0"
             }
         },
         "@algolia/logger-common": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.3.tgz",
-            "integrity": "sha512-kUEAZaBt/J3RjYi8MEBT2QEexJR2kAE2mtLmezsmqMQZTV502TkHCxYzTwY2dE7OKcUTxi4OFlMuS4GId9CWPw=="
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.24.0.tgz",
+            "integrity": "sha512-LLUNjkahj9KtKYrQhFKCzMx0BY3RnNP4FEtO+sBybCjJ73E8jNdaKJ/Dd8A/VA4imVHP5tADZ8pn5B8Ga/wTMA=="
         },
         "@algolia/logger-console": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.3.tgz",
-            "integrity": "sha512-ZWqAlUITktiMN2EiFpQIFCJS10N96A++yrexqC2Z+3hgF/JcKrOxOdT4nSCQoEPvU4Ki9QKbpzbebRDemZt/hw==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.24.0.tgz",
+            "integrity": "sha512-X4C8IoHgHfiUROfoRCV+lzSy+LHMgkoEEU1BbKcsfnV0i0S20zyy0NLww9dwVHUWNfPPxdMU+/wKmLGYf96yTg==",
             "requires": {
-                "@algolia/logger-common": "4.14.3"
+                "@algolia/logger-common": "4.24.0"
+            }
+        },
+        "@algolia/recommend": {
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
+            "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
+            "requires": {
+                "@algolia/cache-browser-local-storage": "4.24.0",
+                "@algolia/cache-common": "4.24.0",
+                "@algolia/cache-in-memory": "4.24.0",
+                "@algolia/client-common": "4.24.0",
+                "@algolia/client-search": "4.24.0",
+                "@algolia/logger-common": "4.24.0",
+                "@algolia/logger-console": "4.24.0",
+                "@algolia/requester-browser-xhr": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/requester-node-http": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            },
+            "dependencies": {
+                "@algolia/client-common": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+                    "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+                    "requires": {
+                        "@algolia/requester-common": "4.24.0",
+                        "@algolia/transporter": "4.24.0"
+                    }
+                },
+                "@algolia/client-search": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+                    "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+                    "requires": {
+                        "@algolia/client-common": "4.24.0",
+                        "@algolia/requester-common": "4.24.0",
+                        "@algolia/transporter": "4.24.0"
+                    }
+                },
+                "@algolia/requester-browser-xhr": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+                    "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
+                    "requires": {
+                        "@algolia/requester-common": "4.24.0"
+                    }
+                },
+                "@algolia/requester-node-http": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+                    "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+                    "requires": {
+                        "@algolia/requester-common": "4.24.0"
+                    }
+                }
             }
         },
         "@algolia/requester-browser-xhr": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.3.tgz",
-            "integrity": "sha512-AZeg2T08WLUPvDncl2XLX2O67W5wIO8MNaT7z5ii5LgBTuk/rU4CikTjCe2xsUleIZeFl++QrPAi4Bdxws6r/Q==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.8.0.tgz",
+            "integrity": "sha512-Gi33fRclktW+zJSmT2Gkntiu+BNkh+50NhfYLALHV4yZ3jH73PYbPNURFa1/NxaUpzPvXrld0BrsHDTS1QBBTQ==",
+            "peer": true,
             "requires": {
-                "@algolia/requester-common": "4.14.3"
+                "@algolia/client-common": "5.8.0"
             }
         },
         "@algolia/requester-common": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.3.tgz",
-            "integrity": "sha512-RrRzqNyKFDP7IkTuV3XvYGF9cDPn9h6qEDl595lXva3YUk9YSS8+MGZnnkOMHvjkrSCKfoLeLbm/T4tmoIeclw=="
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.24.0.tgz",
+            "integrity": "sha512-k3CXJ2OVnvgE3HMwcojpvY6d9kgKMPRxs/kVohrwF5WMr2fnqojnycZkxPoEg+bXm8fi5BBfFmOqgYztRtHsQA=="
+        },
+        "@algolia/requester-fetch": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.8.0.tgz",
+            "integrity": "sha512-ve7ynA+O0KDrA2AAQ62GKQB+HjdHd0gX3tsXwlcfFOd7CYb2+xc+eOrVXV9mSlGS6Ssrd8V0AQ6BMId5KyypwQ==",
+            "peer": true,
+            "requires": {
+                "@algolia/client-common": "5.8.0"
+            }
         },
         "@algolia/requester-node-http": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.3.tgz",
-            "integrity": "sha512-O5wnPxtDRPuW2U0EaOz9rMMWdlhwP0J0eSL1Z7TtXF8xnUeeUyNJrdhV5uy2CAp6RbhM1VuC3sOJcIR6Av+vbA==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.8.0.tgz",
+            "integrity": "sha512-2sv9af4Pg58soGj3F0czK8xT2RVh/cX7UmMMjTQwkp7LK7SMW9OoDmg9FSvU5ge6KH0wd1TrxT/4XgRHc1P/NA==",
+            "peer": true,
             "requires": {
-                "@algolia/requester-common": "4.14.3"
+                "@algolia/client-common": "5.8.0"
             }
         },
         "@algolia/transporter": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.3.tgz",
-            "integrity": "sha512-2qlKlKsnGJ008exFRb5RTeTOqhLZj0bkMCMVskxoqWejs2Q2QtWmsiH98hDfpw0fmnyhzHEt0Z7lqxBYp8bW2w==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.24.0.tgz",
+            "integrity": "sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==",
             "requires": {
-                "@algolia/cache-common": "4.14.3",
-                "@algolia/logger-common": "4.14.3",
-                "@algolia/requester-common": "4.14.3"
+                "@algolia/cache-common": "4.24.0",
+                "@algolia/logger-common": "4.24.0",
+                "@algolia/requester-common": "4.24.0"
             }
         },
         "@ampproject/remapping": {
@@ -3282,19 +3597,19 @@
             }
         },
         "@docsearch/css": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.2.tgz",
-            "integrity": "sha512-dctFYiwbvDZkksMlsmc7pj6W6By/EjnVXJq5TEPd05MwQe+dcdHJgaIn1c8wfsucxHpIsdrUcgSkACHCq6aIhw=="
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.2.tgz",
+            "integrity": "sha512-vKNZepO2j7MrYBTZIGXvlUOIR+v9KRf70FApRgovWrj3GTs1EITz/Xb0AOlm1xsQBp16clVZj1SY/qaOJbQtZw=="
         },
         "@docsearch/react": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.2.tgz",
-            "integrity": "sha512-ugILab2TYKSh6IEHf6Z9xZbOovsYbsdfo60PBj+Bw+oMJ1MHJ7pBt1TTcmPki1hSgg8mysgKy2hDiVdPm7XWSQ==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.2.tgz",
+            "integrity": "sha512-rtZce46OOkVflCQH71IdbXSFK+S8iJZlUF56XBW5rIgx/eG5qoomC7Ag3anZson1bBac/JFQn7XOBfved/IMRA==",
             "requires": {
-                "@algolia/autocomplete-core": "1.7.4",
-                "@algolia/autocomplete-preset-algolia": "1.7.4",
-                "@docsearch/css": "3.3.2",
-                "algoliasearch": "^4.0.0"
+                "@algolia/autocomplete-core": "1.9.3",
+                "@algolia/autocomplete-preset-algolia": "1.9.3",
+                "@docsearch/css": "3.6.2",
+                "algoliasearch": "^4.19.1"
             }
         },
         "@esbuild/android-arm": {
@@ -3543,24 +3858,62 @@
             "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
         },
         "algoliasearch": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.3.tgz",
-            "integrity": "sha512-GZTEuxzfWbP/vr7ZJfGzIl8fOsoxN916Z6FY2Egc9q2TmZ6hvq5KfAxY89pPW01oW/2HDEKA8d30f9iAH9eXYg==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
+            "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
             "requires": {
-                "@algolia/cache-browser-local-storage": "4.14.3",
-                "@algolia/cache-common": "4.14.3",
-                "@algolia/cache-in-memory": "4.14.3",
-                "@algolia/client-account": "4.14.3",
-                "@algolia/client-analytics": "4.14.3",
-                "@algolia/client-common": "4.14.3",
-                "@algolia/client-personalization": "4.14.3",
-                "@algolia/client-search": "4.14.3",
-                "@algolia/logger-common": "4.14.3",
-                "@algolia/logger-console": "4.14.3",
-                "@algolia/requester-browser-xhr": "4.14.3",
-                "@algolia/requester-common": "4.14.3",
-                "@algolia/requester-node-http": "4.14.3",
-                "@algolia/transporter": "4.14.3"
+                "@algolia/cache-browser-local-storage": "4.24.0",
+                "@algolia/cache-common": "4.24.0",
+                "@algolia/cache-in-memory": "4.24.0",
+                "@algolia/client-account": "4.24.0",
+                "@algolia/client-analytics": "4.24.0",
+                "@algolia/client-common": "4.24.0",
+                "@algolia/client-personalization": "4.24.0",
+                "@algolia/client-search": "4.24.0",
+                "@algolia/logger-common": "4.24.0",
+                "@algolia/logger-console": "4.24.0",
+                "@algolia/recommend": "4.24.0",
+                "@algolia/requester-browser-xhr": "4.24.0",
+                "@algolia/requester-common": "4.24.0",
+                "@algolia/requester-node-http": "4.24.0",
+                "@algolia/transporter": "4.24.0"
+            },
+            "dependencies": {
+                "@algolia/client-common": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+                    "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+                    "requires": {
+                        "@algolia/requester-common": "4.24.0",
+                        "@algolia/transporter": "4.24.0"
+                    }
+                },
+                "@algolia/client-search": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+                    "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+                    "requires": {
+                        "@algolia/client-common": "4.24.0",
+                        "@algolia/requester-common": "4.24.0",
+                        "@algolia/transporter": "4.24.0"
+                    }
+                },
+                "@algolia/requester-browser-xhr": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+                    "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
+                    "requires": {
+                        "@algolia/requester-common": "4.24.0"
+                    }
+                },
+                "@algolia/requester-node-http": {
+                    "version": "4.24.0",
+                    "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+                    "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+                    "requires": {
+                        "@algolia/requester-common": "4.24.0"
+                    }
+                }
             }
         },
         "ansi-styles": {
@@ -4604,6 +4957,12 @@
             "requires": {
                 "loose-envify": "^1.1.0"
             }
+        },
+        "search-insights": {
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.2.tgz",
+            "integrity": "sha512-zFNpOpUO+tY2D85KrxJ+aqwnIfdEGi06UH2+xEb+Bp9Mwznmauqc9djbnBibJO5mpfUPPa8st6Sx65+vbeO45g==",
+            "peer": true
         },
         "semver": {
             "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "heroku-postbuild": "npm run build"
     },
     "dependencies": {
-        "@docsearch/react": "^3.3.0",
+        "@docsearch/react": "^3.6.2",
         "@inertiajs/react": "^1.0.0",
         "@vitejs/plugin-react": "^3.0.1",
         "autoprefixer": "^10.4.13",

--- a/resources/js/Components/Layout.jsx
+++ b/resources/js/Components/Layout.jsx
@@ -100,7 +100,7 @@ export default function Layout({ meta, children }) {
         <div className="hidden items-center text-white md:flex">
           <div className="relative -my-2 mr-5">
             {showSearch && (
-              <DocSearch appId="VKGU7LHY9C" indexName="inertiajs" apiKey="cebbd114b9b67501184b39b00f94f765" />
+              <DocSearch appId="VKGU7LHY9C" indexName="inertiajs_v2" apiKey="cebbd114b9b67501184b39b00f94f765" />
             )}
           </div>
           <a className="mr-5 flex items-center hover:text-purple-900" href="https://github.com/inertiajs">


### PR DESCRIPTION
The Algolia Crawler created an `inertiajs_v2` index with the new content, we can now target it in order to redirect search results accordignly

Also updates the `@docsearc/react` library version in order to leverage the UI fixes for search results