### PR TITLE
[V2] Protocol: mark `errors` prop required

### DIFF
--- a/resources/js/Pages/the-protocol.jsx
+++ b/resources/js/Pages/the-protocol.jsx
@@ -56,7 +56,7 @@ export default function () {
             </head>
             <body>
 
-            <div id="app" data-page='{"component":"Event","props":{"event":{"id":80,"title":"Birthday party","start_date":"2019-06-02","description":"Come out and celebrate Jonathan&apos;s 36th birthday party!"}},"url":"/events/80","version":"c32b8e4965f418ad16eaebba1d4e960f"}'></div>
+            <div id="app" data-page='{"component":"Event","props":{"errors":{},"event":{"id":80,"title":"Birthday party","start_date":"2019-06-02","description":"Come out and celebrate Jonathan&apos;s 36th birthday party!"}},"url":"/events/80","version":"c32b8e4965f418ad16eaebba1d4e960f"}'></div>
 
             </body>
             </html>
@@ -111,6 +111,7 @@ export default function () {
             {
               "component": "Event",
               "props": {
+                "errors": {},
                 "event": {
                   "id": 80,
                   "title": "Birthday party",
@@ -137,7 +138,8 @@ export default function () {
           <Strong>component:</Strong> The name of the JavaScript page component.
         </Li>
         <Li>
-          <Strong>props:</Strong> The page props (data).
+          <Strong>props:</Strong> The page props, contains all page data plus an <Code>errors</Code> object that is
+          always present (empty <Code>{}</Code> when no errors).
         </Li>
         <Li>
           <Strong>url:</Strong> The page URL.
@@ -270,7 +272,8 @@ export default function () {
               "props": {
                 "auth": {...},       // NOT included
                 "categories": [...], // NOT included
-                "events": [...]      // included
+                "events": [...],      // included
+                "errors": {}         // always included
               },
               "url": "/events/80",
               "version": "c32b8e4965f418ad16eaebba1d4e960f"


### PR DESCRIPTION
This PR updates the protocol to standardize error handling across protocol adapters.

I want to ensure consistent behavior for the `errors` property across all adapter implementations:
- Laravel adapter already returns `"errors": {}` [prop by default](https://github.com/inertiajs/inertia-laravel/blob/1.x/src/Middleware.php#L56)
- TypeScript types in core library expect `errors` [to be present](https://github.com/inertiajs/inertia/blob/master/packages/core/src/types.ts#L34-L38)
- However, Rails adapter, for example, now includes `errors` prop by default

This change should help to synchronize error handling behavior across the entire protocol.