### PR TITLE
Remove `@next` from client package install commands

### DIFF
--- a/resources/js/Pages/client-side-setup.jsx
+++ b/resources/js/Pages/client-side-setup.jsx
@@ -35,21 +35,21 @@ export default function () {
             name: 'Vue',
             language: 'bash',
             code: dedent`
-              npm install @inertiajs/vue3@next
+              npm install @inertiajs/vue3
             `,
           },
           {
             name: 'React',
             language: 'bash',
             code: dedent`
-              npm install @inertiajs/react@next
+              npm install @inertiajs/react
             `,
           },
           {
             name: 'Svelte',
             language: 'bash',
             code: dedent`
-              npm install @inertiajs/svelte@next
+              npm install @inertiajs/svelte
             `,
           },
         ]}


### PR DESCRIPTION
Now that Inertia 2.0 is no longer tagged as pre-release, it now returns an error when installing the client package.

```bash
npm install @inertiajs/vue3@next

npm ERR! code ETARGET
npm ERR! notarget No matching version found for @inertiajs/vue3@next.
```

I've removed the `@next` tag from the install command but i'm unsure how you'd like to manage this for the legacy docs, if you'd like to add a tag to the install command `@inertiajs/vue3@^1.3.0` or if you'd just like to keep the legacy docs the same (currently `npm install @inertiajs/vue3`). Let me know and I will also update those docs.