### PR TITLE
Add evoMark Inertia Wordpress community adapter

### DIFF
--- a/resources/js/Pages/community-adapters.jsx
+++ b/resources/js/Pages/community-adapters.jsx
@@ -62,10 +62,7 @@ export default function () {
           <A href="https://github.com/skipthedragon/inertia-bundle">Symfony</A>
         </Li>
         <Li>
-          <A href="https://github.com/boxybird/inertia-wordpress">WordPress</A>
-        </Li>
-        <Li>
-          <A href="https://github.com/evo-mark/inertia-wordpress">WordPress (v2 support)</A>
+          <A href="https://github.com/evo-mark/inertia-wordpress">WordPress</A>
         </Li>
         <Li>
           <A href="https://github.com/tbreuss/yii2-inertia">Yii2</A>

--- a/resources/js/Pages/community-adapters.jsx
+++ b/resources/js/Pages/community-adapters.jsx
@@ -65,6 +65,9 @@ export default function () {
           <A href="https://github.com/boxybird/inertia-wordpress">WordPress</A>
         </Li>
         <Li>
+          <A href="https://github.com/evo-mark/inertia-wordpress">WordPress (v2 support)</A>
+        </Li>
+        <Li>
           <A href="https://github.com/tbreuss/yii2-inertia">Yii2</A>
         </Li>
         <Li>


### PR DESCRIPTION
Adds a second community WordPress adapter for Inertia to the list.