### PR TITLE
Fix fragment identifier in routing meta links for Generating URLs Section

### DIFF
--- a/resources/js/Components/H2.jsx
+++ b/resources/js/Components/H2.jsx
@@ -1,5 +1,6 @@
 function kebabCase(str) {
   return str
+    .replace('URL', 'Url')
     .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
     .join('-')
     .toLowerCase()

--- a/resources/js/Pages/routing.jsx
+++ b/resources/js/Pages/routing.jsx
@@ -6,7 +6,7 @@ export const meta = {
   links: [
     { url: '#top', name: 'Defining routes' },
     { url: '#shorthand-routes', name: 'Shorthand routes' },
-    { url: '#generating-routes', name: 'Generating URLs' },
+    { url: '#generating-ur-ls', name: 'Generating URLs' },
   ],
 }
 

--- a/resources/js/Pages/routing.jsx
+++ b/resources/js/Pages/routing.jsx
@@ -6,7 +6,7 @@ export const meta = {
   links: [
     { url: '#top', name: 'Defining routes' },
     { url: '#shorthand-routes', name: 'Shorthand routes' },
-    { url: '#generating-ur-ls', name: 'Generating URLs' },
+    { url: '#generating-urls', name: 'Generating URLs' },
   ],
 }
 


### PR DESCRIPTION
This PR adjusts the section link ID to comply with the output of the kebabCase function, which currently generates `#generating-ur-ls` instead of the intended `#generating-urls`.