### PR TITLE
doc: improve scroll region doc

### DIFF
--- a/resources/js/Pages/scroll-management.jsx
+++ b/resources/js/Pages/scroll-management.jsx
@@ -185,7 +185,7 @@ export default function () {
       <CodeBlock
         language="html"
         children={dedent`
-          <div class="overflow-y-auto" scroll-region>
+          <div class="overflow-y-auto" scroll-region="">
             <!-- Your page content -->
           </div>
         `}


### PR DESCRIPTION
in React, if we not add `=""`, the attribute `scroll-region` is missing

Some packages need to get this attribute to get present in the DOM