### PR TITLE
Update docs to clarify merge() vs deepMerge() usage

### DIFF
--- a/resources/js/Pages/merging-props.jsx
+++ b/resources/js/Pages/merging-props.jsx
@@ -1,4 +1,4 @@
-import { A, Code, H1, H2, P, TabbedCode } from '@/Components'
+import { A, Code, H1, H2, P, TabbedCode, Strong } from '@/Components'
 import dedent from 'dedent-js'
 
 export const meta = {
@@ -26,13 +26,13 @@ export default function () {
       </P>
       <P>
         Use <Code>merge</Code> when merging simple arrays, and <Code>deepMerge</Code> when working with nested objects
-        that contain arrays or complex structures, such as pagination objects.
+        that contain arrays or complex structures, such as <Strong>pagination</Strong> objects.
       </P>
 
       <TabbedCode
         examples={[
           {
-            name: 'Laravel – merging pagination object',
+            name: 'Pagination object',
             language: 'php',
             code: dedent`
             Route::get('/users', function () {
@@ -40,13 +40,13 @@ export default function () {
                 $per_page = request()->input('per_page', 10);
 
                 return Inertia::render('Users/Index', [
-                    'results' => Inertia::deepMerge(User::paginate($page, $per_page)),
+                    'results' => Inertia::deepMerge(User::paginate($per_page, page: $page)),
                 ]);
             });
             `,
           },
           {
-            name: 'Laravel – merging simple array',
+            name: 'Simple array',
             language: 'php',
             code: dedent`
             Route::get('/items', function () {
@@ -91,7 +91,7 @@ export default function () {
                 $per_page = request()->input('per_page', 10);
 
                 return Inertia::render('Users/Index', [
-                    'results' => Inertia::defer(fn() => User::paginate($page, $per_page))->deepMerge(),
+                    'results' => Inertia::defer(fn() => User::paginate($per_page, page: $page))->deepMerge(),
                 ]);
             });
             `,

--- a/resources/js/Pages/merging-props.jsx
+++ b/resources/js/Pages/merging-props.jsx
@@ -32,21 +32,7 @@ export default function () {
       <TabbedCode
         examples={[
           {
-            name: 'Pagination object',
-            language: 'php',
-            code: dedent`
-            Route::get('/users', function () {
-                $page = request()->input('page', 1);
-                $per_page = request()->input('per_page', 10);
-
-                return Inertia::render('Users/Index', [
-                    'results' => Inertia::deepMerge(User::paginate($per_page, page: $page)),
-                ]);
-            });
-            `,
-          },
-          {
-            name: 'Simple array',
+            name: 'Shallow Merge',
             language: 'php',
             code: dedent`
             Route::get('/items', function () {
@@ -64,6 +50,20 @@ export default function () {
 
                 return Inertia::render('Tags/Index', [
                     'tags' => Inertia::merge($tags),
+                ]);
+            });
+            `,
+          },
+          {
+            name: 'Deep Merge',
+            language: 'php',
+            code: dedent`
+            Route::get('/users', function () {
+                $page = request()->input('page', 1);
+                $per_page = request()->input('per_page', 10);
+
+                return Inertia::render('Users/Index', [
+                    'results' => Inertia::deepMerge(User::paginate($per_page, page: $page)),
                 ]);
             });
             `,

--- a/resources/js/Pages/merging-props.jsx
+++ b/resources/js/Pages/merging-props.jsx
@@ -1,4 +1,4 @@
-import { A, Code, H1, H2, P, TabbedCode, Strong } from '@/Components'
+import { A, Code, H1, H2, P, Strong, TabbedCode } from '@/Components'
 import dedent from 'dedent-js'
 
 export const meta = {
@@ -26,7 +26,7 @@ export default function () {
       </P>
       <P>
         Use <Code>merge</Code> when merging simple arrays, and <Code>deepMerge</Code> when working with nested objects
-        that contain arrays or complex structures, such as <Strong>pagination</Strong> objects.
+        that contain arrays or complex structures, such as pagination objects.
       </P>
 
       <TabbedCode
@@ -72,9 +72,13 @@ export default function () {
       />
 
       <P>
-        On the client side, Inertia detects that this prop should be merged. If the prop returns a simple array, it will
-        append the response to the current prop value. If it's a nested object, <Code>deepMerge</Code> ensures a deep
-        merge of the entire structure.
+        On the client side, Inertia detects that this prop should be merged. If the prop returns an array, it will
+        append the response to the current prop value. If it's an object, it will merge the response with the current
+        prop value. If you have opted to <Code>deepMerge</Code>, Inertia ensures a deep merge of the entire structure.
+      </P>
+      <P>
+        <Strong>Of note:</Strong> During the merging process, if the value is an array, the incoming items will be{' '}
+        <em>appended</em> to the existing array, not merged by index.
       </P>
       <P>
         You can also combine <A href="/deferred-props">deferred props</A> with mergeable props to defer the loading of

--- a/resources/js/Pages/merging-props.jsx
+++ b/resources/js/Pages/merging-props.jsx
@@ -21,13 +21,18 @@ export default function () {
       </P>
       <H2>Server side</H2>
       <P>
-        To specify that a prop should be merged, you can use the <Code>merge</Code> method on the prop value.
+        To specify that a prop should be merged, you can use the <Code>merge</Code> or <Code>deepMerge</Code> method on
+        the prop value.
       </P>
-      {/* TODO: Come up with real pagination example, cookbook style */}
+      <P>
+        Use <Code>merge</Code> when merging simple arrays, and <Code>deepMerge</Code> when working with nested objects
+        that contain arrays or complex structures, such as pagination objects.
+      </P>
+
       <TabbedCode
         examples={[
           {
-            name: 'Laravel',
+            name: 'Laravel – merging pagination object',
             language: 'php',
             code: dedent`
             Route::get('/users', function () {
@@ -35,18 +40,41 @@ export default function () {
                 $per_page = request()->input('per_page', 10);
 
                 return Inertia::render('Users/Index', [
-                    'results' => Inertia::merge(User::paginate($page, $per_page)),
+                    'results' => Inertia::deepMerge(User::paginate($page, $per_page)),
+                ]);
+            });
+            `,
+          },
+          {
+            name: 'Laravel – merging simple array',
+            language: 'php',
+            code: dedent`
+            Route::get('/items', function () {
+                // Static array of tags
+                $allTags = [
+                    'Laravel', 'React', 'Vue', 'Tailwind', 'Inertia',
+                    'PHP', 'JavaScript', 'TypeScript', 'Docker', 'Vite',
+                ];
+
+                // Load chunk by page
+                $page = request()->input('page', 1);
+                $perPage = 5;
+                $offset = ($page - 1) * $perPage;
+                $tags = array_slice($allTags, $offset, $perPage);
+
+                return Inertia::render('Tags/Index', [
+                    'tags' => Inertia::merge($tags),
                 ]);
             });
             `,
           },
         ]}
       />
-      {/* TODO: Come up with real infinite scroll example, cookbook style */}
+
       <P>
-        On the client side, Inertia detects that this prop should be merged. If the prop returns an array, it will
-        append the response to the current prop value. If it's an object, it will merge the response with the current
-        prop value.
+        On the client side, Inertia detects that this prop should be merged. If the prop returns a simple array, it will
+        append the response to the current prop value. If it's a nested object, <Code>deepMerge</Code> ensures a deep
+        merge of the entire structure.
       </P>
       <P>
         You can also combine <A href="/deferred-props">deferred props</A> with mergeable props to defer the loading of
@@ -63,7 +91,7 @@ export default function () {
                 $per_page = request()->input('per_page', 10);
 
                 return Inertia::render('Users/Index', [
-                    'results' => Inertia::defer(fn() => User::paginate($page, $per_page))->merge(),
+                    'results' => Inertia::defer(fn() => User::paginate($page, $per_page))->deepMerge(),
                 ]);
             });
             `,


### PR DESCRIPTION
**Description:**  
Due to the new `deepMerge()` support introduced in [inertia-laravel#679](https://github.com/inertiajs/inertia-laravel/pull/679) and [inertia#2069](https://github.com/inertiajs/inertia/pull/2069), this PR updates the "Merging props" documentation to clarify when to use `merge()` (for simple arrays) and when to use `deepMerge()` (for nested objects like pagination). Updated examples reflect practical use cases for both methods.