### PR TITLE
docs: add 'server side' docs to load when visible

### DIFF
--- a/resources/js/Pages/load-when-visible.jsx
+++ b/resources/js/Pages/load-when-visible.jsx
@@ -19,6 +19,32 @@ export default function () {
         <Code>WhenVisible</Code> component as a convenient way to load data when an element becomes visible in the
         viewport.
       </P>
+
+      <H2>Server side</H2>
+      <P>
+        To only load a prop when visible, you can use the <Code>optional</Code> method when returning your response.
+        This method receives a callback that returns the prop data. The callback will be executed in a separate request
+        once the element becomes visible.
+      </P>
+      <TabbedCode
+        examples={[
+          {
+            name: 'Laravel',
+            language: 'php',
+            code: dedent`
+            Route::get('/users', function () {
+                return Inertia::render('Users/Index', [
+                    'users' => User::all(),
+                    'roles' => Role::all(),
+                    'permissions' => Inertia::optional(fn () => Permission::all()),
+                ]);
+            });
+            `,
+          },
+        ]}
+      />
+
+      <H2>Client side</H2>
       <P>
         The <Code>WhenVisible</Code> component accepts a <Code>data</Code> prop that specifies the key of the prop to
         load. It also accepts a <Code>fallback</Code> prop that specifies a component to render while the data is


### PR DESCRIPTION
# What & Why

This updates the 'Load when visible' page to be explicit about what's expected on the server side.

I was looking to use `WhenVisible` but wasn't sure how to pair the client side with the server side. Being clear about what's expected will help _all the people_.

# Notes/thoughts
  - I'm only 90% sure it's recommended to use `Inertia::optional` when using `WhenVisible`


# Demo
![CleanShot 2025-04-15 at 17 13 02@2x](https://github.com/user-attachments/assets/4e061b2f-9def-42ef-b702-28ba9682dc4a)
