### PR TITLE
Add Inertia4J to community adapters

### DIFF
--- a/resources/js/Pages/community-adapters.jsx
+++ b/resources/js/Pages/community-adapters.jsx
@@ -68,6 +68,9 @@ export default function () {
           <A href="https://kaiofelps.github.io/inertia-rust/">Rust</A>
         </Li>
         <Li>
+          <A href="https://github.com/Inertia4J/inertia4j">Spring/Ktor</A>
+        </Li>
+        <Li>
           <A href="https://github.com/skipthedragon/inertia-bundle">Symfony</A>
         </Li>
         <Li>


### PR DESCRIPTION
Adds the Inertia4J adapter for Spring and Ktor to the list of community adapters