### PR TITLE
fix: add missing @docsearch/css dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "heroku-postbuild": "npm run build"
     },
     "dependencies": {
+        "@docsearch/css": "^3.9.0",
         "@docsearch/react": "^3.6.2",
         "@inertiajs/react": "^1.0.0",
         "@vitejs/plugin-react": "^3.0.1",


### PR DESCRIPTION
This PR addresses an issue where the `@docsearch/css` package was a missing dependency, causing build failures.

**Problem:**
When attempting to build the application assets locally using `pnpm run build`, the process failed due to `@docsearch/css` not being found. This dependency is required and used within `resources/js/Components/Layout.jsx`.

**Steps to Reproduce:**
1.  Clone the repository.
2.  Install dependencies: `pnpm install`
3.  Attempt to build assets: `pnpm run build` (This will fail)

**Solution:**
Added `@docsearch/css` to the project's dependencies to ensure successful asset compilation.

**Verification:**
After this change, `pnpm run build` now completes successfully.