### PR TITLE
fix: missing react import

### DIFF
--- a/resources/js/Pages/client-side-setup.jsx
+++ b/resources/js/Pages/client-side-setup.jsx
@@ -87,6 +87,7 @@ export default function () {
             code: dedent`
               import { createInertiaApp } from '@inertiajs/react'
               import { createRoot } from 'react-dom/client'
+              import React from 'react'
 
               createInertiaApp({
                 resolve: name => {


### PR DESCRIPTION
When using JSX in React, the import of the said library is required. When one follows the installation documentation step by step -- this error is always inevitable.