### PR TITLE
Unify version hashes

### DIFF
--- a/resources/js/Pages/the-protocol.jsx
+++ b/resources/js/Pages/the-protocol.jsx
@@ -213,6 +213,9 @@ export default function () {
           </div>
         </div>
       </div>
+      <P>
+        You can read more about this on the <A href="/asset-versioning">asset versioning</A> page.
+      </P>
       <H2>Partial reloads</H2>
       <P>
         When making Inertia requests, the partial reload option allows you to request a subset of the props (data) from

--- a/resources/js/Pages/the-protocol.jsx
+++ b/resources/js/Pages/the-protocol.jsx
@@ -119,7 +119,7 @@ export default function () {
                 }
               },
               "url": "/events/80",
-              "version": "c32b8e4965f418ad16eaebba1d4e960f",
+              "version": "6b16b94d7c51cbe5b1fa42aac98241d5",
               "encryptHistory": true,
               "clearHistory": false
             }
@@ -273,7 +273,7 @@ export default function () {
                 "events": [...]      // included
               },
               "url": "/events/80",
-              "version": "c32b8e4965f418ad16eaebba1d4e960f"
+              "version": "6b16b94d7c51cbe5b1fa42aac98241d5"
             }
           `}
         </CodeBlock>


### PR DESCRIPTION
Use the same version hash in the request and response for clarity. It also adds a link to the Assert Versioning page.

Fixes #410.