### PR TITLE
Change active tab selection logic in TabbedCode component

### DIFF
--- a/resources/js/Components/TabbedCode.jsx
+++ b/resources/js/Components/TabbedCode.jsx
@@ -17,7 +17,7 @@ const TabbedCode = ({ className, examples, height }) => {
   const [codeTabs, setCodeTabs] = useContext(CodeTabContext) || useState({ unknown: 0 })
   const tabType = guessTabType(examples.map(example => example.name))
   const exampleIndex = examples.findIndex(example => codeTabs[tabType] === example.name)
-  const activeTab = exampleIndex < 0 ? 0 : exampleIndex
+  const activeTab = exampleIndex < 0 ? (examples.length - 1) : exampleIndex
 
   return (
     <div className={className || 'my-8 overflow-hidden rounded'}>


### PR DESCRIPTION
In some pages, if the user clicks on the "Svelte 4" and "Svelte 5" tabs, some examples with only "Svelte" will switch to first tab "Vue".

I'm changing the selection logic here, and if the tab index can't find the mapped index, just switch it to the last tab.

So if the user clicks on the "Svelte 4" or "Svelte 5" tab, these examples will stick to the "Svelte" instead of the first tab.

Conversely, when the user clicks "Svelte", the other examples will change to "Svelte 5".

I think this change can make Svelte users more comfortable reading documents.