### PR TITLE
Remove mention of Breeze and Jetstream

### DIFF
--- a/resources/js/Pages/authentication.jsx
+++ b/resources/js/Pages/authentication.jsx
@@ -19,7 +19,7 @@ export default function () {
         with Laravel.
       </P>
       <P>
-        Laravel's <A href="https://laravel.com/docs/starter-kits">starter kits</A>, Breeze and Jetstream, provide
+        Laravel's <A href="https://laravel.com/docs/starter-kits">starter kits</A> provide
         out-of-the-box scaffolding for new Inertia applications, including authentication.
       </P>
     </>


### PR DESCRIPTION
In the authentication page of the docs, there are mentions of Breeze and Jetstream, which are no longer "things" in the new starter kits.