### PR TITLE
Change documentation about SSR (hydrateRoot hook)

### DIFF
--- a/resources/js/Pages/server-side-rendering.jsx
+++ b/resources/js/Pages/server-side-rendering.jsx
@@ -362,7 +362,7 @@ export default function () {
       </Vue>
       <React>
         <P>
-          To enable client-side hydration in a React app, update your <Code>ssr.js</Code> file to use{' '}
+          To enable client-side hydration in a React app, update your <Code>app.js</Code> file to use{' '}
           <Code>hydrateRoot</Code> instead of <Code>createRoot</Code>:
         </P>
       </React>


### PR DESCRIPTION
In newest version of RILT stack you have to update 'hydrateRoot' hook in app.js (or app.tsx) instead of ssr.js (or ssr.tsx)