### PR TITLE
fix(ssr): add spacing to Laravel starter kits section

### DIFF
--- a/resources/js/Pages/server-side-rendering.jsx
+++ b/resources/js/Pages/server-side-rendering.jsx
@@ -45,7 +45,7 @@ export default function () {
       </Notice>
       <H2>Laravel starter kits</H2>
       <P>
-        If you are using <A href="https://laravel.com/docs/starter-kits">Laravel Starter Kits</A>, Inertia SSR is 
+        If you are using <A href="https://laravel.com/docs/starter-kits">Laravel Starter Kits</A>, Inertia SSR is{' '}
         <A href="https://laravel.com/docs/starter-kits#inertia-ssr">supported</A> through a build command:
       </P>
       <TabbedCode


### PR DESCRIPTION
This PR fixes a spacing issue on the **SSR** page, specifically in the Laravel starter kits section.
Specifically, the word **is** and the `<a>` tag wrapping **supported** were stuck together, resulting in a visually awkward rendering.