### PR TITLE
Update cancelable events

### DIFF
--- a/resources/js/Pages/events.jsx
+++ b/resources/js/Pages/events.jsx
@@ -281,7 +281,7 @@ export default function () {
       />
       <H2>Cancelling events</H2>
       <P>
-        Some events, such as <Code>before</Code>, <Code>invalid</Code>, and <Code>error</Code>, support cancellation,
+        Some events, such as <Code>before</Code>, <Code>exception</Code>, and <Code>invalid</Code>, support cancellation,
         allowing you to prevent Inertia's default behavior. Just like native events, the event will be cancelled if only
         one event listener calls <Code>event.preventDefault()</Code>.
       </P>


### PR DESCRIPTION
The `error` event is not cancelable, but the `exception` does:

https://github.com/inertiajs/inertia/blob/930ea8725989fdec43722238b0989d8536db4acd/packages/core/src/events.ts
